### PR TITLE
WB-1697 Add min confidence from classifier

### DIFF
--- a/routes/core/detections/clustered.js
+++ b/routes/core/detections/clustered.js
@@ -53,6 +53,10 @@ const models = require('../../../modelsTimescale')
  *         description: Limit results to a selected stream
  *         in: query
  *         type: string
+ *       - name: min_confidence
+ *         description: Return results above a minimum confidence (by default will return above minimum confidence of the classifier)
+ *         in: query
+ *         type: float
  *       - name: descending
  *         description: Order by descending time (most recent first)
  *         in: query
@@ -90,6 +94,7 @@ router.get('/', authenticatedWithRoles('rfcxUser'), (req, res) => {
   params.convert('interval').default('1d').toTimeInterval()
   params.convert('aggregate').default('count').toAggregateFunction()
   params.convert('field').default('id').isEqualToAny(models.Detection.attributes.full)
+  params.convert('min_confidence').optional().toFloat()
   params.convert('descending').default(false).toBoolean()
   params.convert('limit').default(100).toInt()
   params.convert('offset').default(0).toInt()
@@ -98,7 +103,8 @@ router.get('/', authenticatedWithRoles('rfcxUser'), (req, res) => {
     .then(() => {
       const streamId = convertedParams.stream_id
       const { start, end, interval, aggregate, field, descending, limit, offset } = convertedParams
-      return detectionsService.timeAggregatedQuery(start, end, streamId, interval, aggregate, field, descending, limit, offset)
+      const minConfidence = convertedParams.min_confidence
+      return detectionsService.timeAggregatedQuery(start, end, streamId, interval, aggregate, field, minConfidence, descending, limit, offset)
     })
     .then(detections => res.json(detections))
     .catch(httpErrorHandler(req, res, 'Failed getting detections'))

--- a/routes/core/detections/stream.js
+++ b/routes/core/detections/stream.js
@@ -46,6 +46,10 @@ function checkAccess (streamId, req) {
  *         description: List of clasification identifiers
  *         in: query
  *         type: array
+ *       - name: min_confidence
+ *         description: Return results above a minimum confidence (by default will return above minimum confidence of the classifier)
+ *         in: query
+ *         type: float
  *       - name: limit
  *         description: Maximum number of results to return
  *         in: query
@@ -77,16 +81,17 @@ router.get('/:streamId/detections', authenticatedWithRoles('rfcxUser'), function
   params.convert('start').toMomentUtc()
   params.convert('end').toMomentUtc()
   params.convert('classifications').optional().toArray()
+  params.convert('min_confidence').optional().toFloat()
   params.convert('limit').optional().toInt()
   params.convert('offset').optional().toInt()
 
   return params.validate()
-    // .then(() => checkAccess(streamId, req))
     .then(() => {
       const { start, end, classifications, limit, offset } = convertedParams
-      return detectionsService.query(start, end, streamId, classifications, limit, offset)
+      const minConfidence = convertedParams.min_confidence
+      return detectionsService.query(start, end, streamId, classifications, minConfidence, limit, offset)
     })
-    .then((detections) => res.json(detections))
+    .then(detections => res.json(detections))
     .catch(httpErrorHandler(req, res, 'Failed getting detections'))
 })
 


### PR DESCRIPTION
Two small changes:
- added optional`min_confidence` query string parameter to `/detections` and `/clustered-detections`
- by default (if no parameter is given) then `min_confidence` corresponds to the classifier's minimum confidence
- both endpoints will now no longer return all detections, but will return them only detections above the min_confidence