### PR TITLE
feature/WB-1951 heatmap caching

### DIFF
--- a/routes/internal/prediction/indices.js
+++ b/routes/internal/prediction/indices.js
@@ -48,6 +48,7 @@ router.post('/index-values', authenticatedWithRoles('systemUser'), function (req
         const offsetTime = time.clone().add(i * step, 's')
         return { streamId, indexId, time: offsetTime, value }
       })
+      indexValuesService.clearHeatmapCache(streamId, time.valueOf()) // it's async, but we don't need to wait for it
       return indexValuesService.create(objects)
     })
     .then(detections => res.sendStatus(201))

--- a/services/indices/values.js
+++ b/services/indices/values.js
@@ -2,6 +2,8 @@ const moment = require('moment')
 const models = require('../../modelsTimescale')
 const { propertyToFloat } = require('../../utils/formatters/object-properties')
 const { timeBucketAttribute, aggregatedValueAttribute, timeAggregatedQueryAttributes } = require('../../utils/timeseries/time-aggregated-query')
+const platform = process.env.PLATFORM || 'amazon';
+const storageService = require(`../storage/${platform}`)
 
 function defaultQueryOptions (streamId, index, start, end, descending, limit, offset) {
   return {
@@ -58,4 +60,29 @@ function create (values) {
     })))
 }
 
-module.exports = { query, timeAggregatedQuery, create }
+function getHeatmapStoragePath (streamId, start, end, interval, aggregate) {
+  return `${streamId}/heatmap/${start.valueOf()}_${end.valueOf()}_${interval}_${aggregate}.png`
+}
+
+async function clearHeatmapCache(streamId, timestamp) {
+  const prefix = `${streamId}/heatmap/`
+  const files = await storageService.listFiles(process.env.STREAMS_CACHE_BUCKET, prefix)
+  for (let file of files) {
+    const filePath = storageService.getFilePath(file)
+    const filename = filePath.replace(prefix, '')
+    const filenameParts = filename.split('_')
+    const start = parseInt(filenameParts[0])
+    const end = parseInt(filenameParts[1])
+    if (start <= timestamp && timestamp <= end) {
+      await storageService.deleteFile(process.env.STREAMS_CACHE_BUCKET, filePath)
+    }
+  }
+}
+
+module.exports = {
+  query,
+  timeAggregatedQuery,
+  create,
+  getHeatmapStoragePath,
+  clearHeatmapCache
+}

--- a/services/storage/amazon.js
+++ b/services/storage/amazon.js
@@ -35,6 +35,15 @@ function exists(Bucket, Key) {
   })
 }
 
+async function listFiles(Bucket, path) {
+  const files = await s3Client.listObjects({ Bucket, Prefix: path }).promise()
+  return files.Contents
+}
+
+function getFilePath(file) {
+  return file.Key
+}
+
 function download (Bucket, remotePath, localPath) {
   return new Promise((resolve, reject) => {
     try {
@@ -85,6 +94,15 @@ function upload(Bucket, Key, localPath) {
   return s3Client.putObject(opts).promise();
 }
 
+function uploadBuffer(Bucket, Key, buffer) {
+  const opts = {
+    Bucket,
+    Key,
+    Body: buffer
+  };
+  return s3Client.upload(opts).promise();
+}
+
 function deleteFile(Bucket, Key) {
   const opts = { Bucket, Key };
   return s3Client.deleteObject(opts).promise();
@@ -111,9 +129,12 @@ function deleteFiles(Bucket, Keys) {
 module.exports = {
   getSignedUrl,
   exists,
+  listFiles,
+  getFilePath,
   download,
   getReadStream,
   upload,
+  uploadBuffer,
   deleteFile,
   deleteFiles,
 }

--- a/services/storage/google.js
+++ b/services/storage/google.js
@@ -24,6 +24,15 @@ function exists(bucket, key) {
     .then(data => data[0]);
 }
 
+async function listFiles(bucket, path) {
+  const data = await storage.bucket(bucket).getFiles({ prefix: path })
+  return data[0]
+}
+
+function getFilePath(file) {
+  return file.metadata.name
+}
+
 function download (bucket, remotePath, localPath) {
   return storage.bucket(bucket).file(remotePath).download({ destination: localPath })
 }
@@ -34,6 +43,10 @@ function getReadStream(bucket, key) {
 
 function upload(bucket, key, localPath) {
   return storage.bucket(bucket).upload(localPath, { destination: key });
+}
+
+function uploadBuffer(bucket, key, buffer) {
+  return storage.bucket(bucket).file(key).save(buffer);
 }
 
 function deleteFile(bucket, key) {
@@ -50,9 +63,12 @@ async function deleteFiles(bucket, keys) {
 module.exports = {
   getSignedUrl,
   exists,
+  listFiles,
+  getFilePath,
   download,
   getReadStream,
   upload,
+  uploadBuffer,
   deleteFile,
   deleteFiles,
 }


### PR DESCRIPTION
The following stuff will work quite well for static user-ingested streams which are not constantly getting new files (like guardian streams). For guardian streams it will also work well for all half-years except current one, because cache will be cleared each time Prediction Service sends acoustic index.
We are not recalculating it after we clear the cache, because it will be very resource-consuming to do it on each Prediction Service request I think...