### PR TITLE
WB-2312 add earth rangers service and send request on event trigger call

### DIFF
--- a/config/env_vars.js.sample
+++ b/config/env_vars.js.sample
@@ -116,9 +116,9 @@ exports.env = {
   // ARBIMON_ENABLED: 'false'
   // ARBIMON_BASE_URL: 'https://arbimon.rfcx.org/',
 
-  /// When `EARTH_RANGERS_ENABLED` is set to `true` then the other env vars are required.
-  // EARTH_RANGERS_ENABLED: 'false'
-  // EARTH_RANGERS_BASE_URL: 'https://sandbox.pamdas.org/',
-  // EARTH_RANGERS_ACCESS_TOKEN: '',
+  /// When `EARTHRANGER_ENABLED` is set to `true` then the other env vars are required.
+  // EARTHRANGER_ENABLED: 'false'
+  // EARTHRANGER_BASE_URL: 'https://sandbox.pamdas.org/',
+  // EARTHRANGER_ACCESS_TOKEN: '',
 
 }

--- a/routes/v2/events/events.js
+++ b/routes/v2/events/events.js
@@ -16,10 +16,10 @@ const guardiansService = require('../../../services/guardians/guardians-service'
 const hasRole = require('../../../middleware/authorization/authorization').hasRole
 const Converter = require('../../../utils/converter/converter')
 const sequelize = require('sequelize')
-const earthRangersEnabled = `${process.env.EARTH_RANGERS_ENABLED}` === 'true'
+const earthRangerEnabled = `${process.env.EARTHRANGER_ENABLED}` === 'true'
 const moment = require('moment')
-if (earthRangersEnabled) {
-  var earthRangersService = require('../../../services/earth-rangers')
+if (earthRangerEnabled) {
+  var earthRangerService = require('../../../services/earthranger')
 }
 
 router.route('/')
@@ -134,9 +134,9 @@ router.route('/:guid/trigger')
         res.status(200).send({ success: true })
       })
       .then(async () => {
-        if (earthRangersEnabled) {
+        if (earthRangerEnabled) {
           try {
-            await earthRangersService.createEvent({
+            await earthRangerService.createEvent({
               event_type: 'acoustic_detection',
               time: moment.utc(eventData.event.audioMeasuredAt).toISOString(),
               location: {

--- a/services/earthranger/index.js
+++ b/services/earthranger/index.js
@@ -1,6 +1,6 @@
 const rp = require('request-promise')
-const baseUrl = process.env.EARTH_RANGERS_BASE_URL
-const token = process.env.EARTH_RANGERS_ACCESS_TOKEN
+const baseUrl = process.env.EARTHRANGER_BASE_URL
+const token = process.env.EARTHRANGER_ACCESS_TOKEN
 
 function createEvent (body) {
   const options = {


### PR DESCRIPTION
The following env vars will required to be set on prod:
```
  EARTH_RANGERS_ENABLED: 'true',
  EARTH_RANGERS_BASE_URL: 'https://sandbox.pamdas.org/',
  EARTH_RANGERS_ACCESS_TOKEN: '<token from pamdas dashboard>',
```