### PR TITLE
[Bug] HTTP 4xx status should not show as an error in Grafana

### DIFF
--- a/utils/http-errors.js
+++ b/utils/http-errors.js
@@ -1,43 +1,37 @@
-var options = {
-
+const options = {
   400: {
     default: 'Missing required parameters'
   },
-
+  403: {
+    default: 'Not authorized to access this resource',
+    user: 'Only users are authorized to access this resource'
+  },
   404: {
     default: 'Not Found',
     database: 'Record Not Found'
   },
-
   500: {
     default: 'Internal Server Error',
     database: 'Server Error While Retrieving Data',
     parse: 'Failed to parse input'
   },
-
   501: {
     default: 'Not Implemented'
-  },
-
-  403: {
-    default: 'Not authorized to access this resource',
-    user: 'Only users are authorized to access this resource'
   }
-
 }
 
-var httpError = function (req, res, code, context, mes) {
-  var message = mes || (((context != null) && (options['' + code]['' + context] != null)) ? options['' + code]['' + context] : options['' + code].default)
+function httpError (req, res, code, context, mes) {
+  const message = mes || (((context != null) && (options['' + code]['' + context] != null)) ? options['' + code]['' + context] : options['' + code].default)
   code = parseInt(code)
-  var json = {
+  const json = {
     message: message,
     error: {
       status: code
     }
   }
-  var logger = code === 400 ? console.warn : console.error
-  logger('Http error', { req: req.guid, message, context })
-  res.status(parseInt(code)).json(json)
+  const logger = code >= 400 && code <= 499 ? console.warn : console.error
+  logger(`Http handler: request ${req.guid}, message "${message}", context ${JSON.stringify(context)}`)
+  res.status(code).json(json)
 }
 
 module.exports = httpError


### PR DESCRIPTION
Small fix to stop non-errors as showing up as errors in our logs (and hence causing alerts).