### PR TITLE
Explanation on how team can add/edit env vars

### DIFF
--- a/build/k8s/http/http-api.yaml
+++ b/build/k8s/http/http-api.yaml
@@ -1,5 +1,5 @@
-apiVersion: apps/v1
 kind: Deployment
+apiVersion: apps/v1
 metadata:
   name: api
   namespace: [NAMESPACE]
@@ -14,7 +14,10 @@ spec:
     spec:
       containers:
         - name: api
-          image: 887044485231.dkr.ecr.eu-west-1.amazonaws.com/[REPO_NAME]:latest
+          image: 887044485231.dkr.ecr.eu-west-1.amazonaws.com/api_staging:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 3000
           resources:
             requests:
               memory: "512Mi"
@@ -22,8 +25,9 @@ spec:
             limits:
               memory: "2000Mi"
               cpu: "2"
-          ports:
-            - containerPort: 8081
+          envFrom:
+            - secretRef:
+                name: api-secrets
           env:
             - name: NEW_RELIC_NO_CONFIG_FILE
               value: "true"


### PR DESCRIPTION
TLDR; Use: `kubectl patch secret api-secrets --namespace staging -p='{"stringData":{"X_API_KEY": "n0tTeLLiNg"}}' -v=1`

It does the base 64 encoding for you, it handles add/edit and it is only one line.