### PR TITLE
CS-331 Detection review from Neo4j is saved in TimescaleDB also

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="1.0.2"></a>
+## 1.0.2 (2021-02-XX)
+
+
+### Features
+* **core:** Detection review from Neo4j is saved in TimescaleDB also ([CS-331](https://jira.rfcx.org/browse/CS-331))
+
+
 <a name="1.0.1"></a>
 ## 1.0.1 (2021-02-02)
 

--- a/DEPLOYMENT_NOTES.md
+++ b/DEPLOYMENT_NOTES.md
@@ -1,5 +1,9 @@
 # API Deployment Notes
 
+## v1.0.2
+
+_None_
+
 ## v1.0.1
 
 - Delete `20200708000001-create-detection-review.js` from `sequelize.migrations` table in TimescaleDB.

--- a/routes/v2/events/events.js
+++ b/routes/v2/events/events.js
@@ -183,6 +183,7 @@ router.route('/:guid/review')
 
     const user = usersService.getUserDataFromReq(req)
     const timestamp = (new Date()).valueOf()
+    let event
 
     return params.validate()
       .then(() => {
@@ -203,10 +204,12 @@ router.route('/:guid/review')
       .then(() => {
         return eventsServiceNeo4j.reviewEvent(req.params.guid, transformedParams.confirmed, user, timestamp, transformedParams.unreliable)
       })
-      .then(() => {
+      .then((data) => {
+        event = data
         return eventsServiceNeo4j.reviewAudioWindows(transformedParams.windows, user, timestamp, transformedParams.unreliable)
       })
-      .then(() => {
+      .then((winds) => {
+        eventsServiceNeo4j.saveInTimescaleDB(event, winds, transformedParams.windows, req.rfcx.auth_token_info.owner_id)
         res.status(200).send({ success: true })
       })
       .catch(EmptyResultError, e => httpError(req, res, 404, null, e.message))

--- a/services/annotations/index.js
+++ b/services/annotations/index.js
@@ -153,7 +153,7 @@ function create (annotation) {
     updated_by_id: userId,
     is_positive: isPositive
   }
-  return models.Annotation.findOrCreate({ where, defaults }).spread(annotation, created => formatFull(annotation))
+  return models.Annotation.findOrCreate({ where, defaults }).spread((annotation, created) => formatFull(annotation))
 }
 
 function get (annotationId) {


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves [CS-331](https://jira.rfcx.org/browse/CS-331)
- [x] Release notes updated
- [x] Deployment notes updated

## 📝 Summary

### Features
* **core:** Detection review from Neo4j is saved in TimescaleDB also ([CS-331](https://jira.rfcx.org/browse/CS-331))

## 📸 Screenshots

<img width="1325" alt="Screenshot 2021-02-02 at 23 34 43" src="https://user-images.githubusercontent.com/2122991/106660798-83377a80-65b1-11eb-8acb-6f18868fa4b1.png">
<img width="1708" alt="Screenshot 2021-02-02 at 23 34 35" src="https://user-images.githubusercontent.com/2122991/106660811-86326b00-65b1-11eb-94dc-f93d105a50a8.png">

## 🛑 Problems

- Detections may have different time values right now

## 💡 More ideas

None
