### PR TITLE
Enable clustered detections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
+<a name="1.0.5"></a>
+## 1.0.5 (2021-02-12)
+
+### Bug Fixes
+* **core:** Enable clustered detections, fix `field` bug (previously defaulted to `id`)
+
+
 <a name="1.0.4"></a>
 ## 1.0.4 (2021-02-09)
 
-### Bug Fixs
+### Bug Fixes
 * **core:** Fix wrong model spelling on classifiers endpoint ([CS-478](https://jira.rfcx.org/browse/CS-478))
 
 


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves none
- [x] API docs updated
- [x] Release notes updated
- [x] Deployment notes n/a
- [x] DB migrations n/a

## 📝 Summary

- Re-enable the clustered detections
- _Change default `field` from `id` to `start`_

## 📸 Screenshots

_None_

## 🛑 Problems

_None_

## 💡 More ideas

_None_
