### PR TITLE
CE-106 Do not request min and max segment time for stream on segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * **media:** Add unit tests for `convertAudio` function of `segment-file-utils` service ([CS-439](https://jira.rfcx.org/browse/CS-439))
 * **core:** refactor setup script
 
+### Performance Improvements
+* **core:** Do not request min and max segment time for stream on segment creation - get it from segment ([CE-106](https://jira.rfcx.org/browse/CE-106))
+
 
 ## 1.0.7 (2021-02-22)
 

--- a/routes/core/stream-segments/stream.js
+++ b/routes/core/stream-segments/stream.js
@@ -55,7 +55,7 @@ router.post('/:streamId/stream-segments', hasRole(['systemUser']), function (req
       convertedParams.stream_id = streamId
       await streamSegmentService.findOrCreateRelationships(convertedParams)
       const streamSegment = await streamSegmentService.create(convertedParams, { joinRelations: true })
-      await streamsService.refreshStreamStartEnd(stream) // refresh start and end columns of releated stream
+      await streamsService.refreshStreamStartEnd(stream, streamSegment) // refresh start and end columns of releated stream
       await streamSegment.reload() // reload segment model to apply stream model updates
       return res.status(201).json(streamSegmentService.format(streamSegment))
     })


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves [CE-106](https://jira.rfcx.org/browse/CE-106)
- [x] Release notes updated
- [x] Deployment notes n/a
- [x] Unit tests n/a
- [x] DB migrations n/a

## 📝 Summary

- Do not request min and max segment time for stream on segment creation - get it from segment

## 📸 Examples

## 🛑 Problems

## 💡 More ideas
