### PR TITLE
CE-310 shorten /streams/id/detections body to 5 items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.17 (2012-03-XX)
+
+### Features
+* **core:** Shorten /streams/id/detections body payload to 5 items ([CE-310](https://jira.rfcx.org/browse/CE-310))
+
+
 ## 1.0.15-hotfix.0 (2021-03-13)
 
 ### Bug Fixes

--- a/middleware/logging.js
+++ b/middleware/logging.js
@@ -9,6 +9,15 @@ module.exports = expressWinston.logger({
     winston.format.simple()
   ),
   meta: false,
-  msg: '{{req.method}} {{res.statusCode}} {{req.url}} {{res.responseTime}} Authorization: {{req.headers.authorization}} {{JSON.stringify(req.body)}}',
+  msg: function (req, res) {
+    let body = req.body
+    // shorten long detections body request
+    if (/streams\/([a-zA-Z]|\d)+\/detections/.test(req.url) && req.body.length > 5) {
+      const totalLength = body.length
+      body = body.slice(0, 5)
+      body.push(`Other ${totalLength - 5} items were cropped...`)
+    }
+    return `${req.method} ${res.statusCode} ${req.url} ${res.responseTime} Authorization: ${req.headers.authorization} ${JSON.stringify(body)}`
+  },
   expressFormat: false
 })


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves [CS-XXX](https://jira.rfcx.org/browse/CS-XXX)
- [x] API docs n/a
- [x] Release notes updated
- [x] Deployment notes n/a
- [x] Unit tests n/a
- [x] DB migrations n/a

## 📝 Summary

- feature/CE-310-shorten-detections-body

## 📸 Examples

<img width="1792" alt="Screenshot 2021-03-15 at 12 58 55" src="https://user-images.githubusercontent.com/2122991/111145332-2b6d3580-8599-11eb-8e23-59b177251a01.png">
<img width="1792" alt="Screenshot 2021-03-15 at 14 15 07" src="https://user-images.githubusercontent.com/2122991/111145340-2dcf8f80-8599-11eb-95d9-675c7234a219.png">

## 🛑 Problems

## 💡 More ideas
