### PR TITLE
Hotfix: Filename not added to meta when meta is null

### DIFF
--- a/services/arbimon/index.js
+++ b/services/arbimon/index.js
@@ -125,15 +125,16 @@ function matchSegmentToRecording (segment, opts = {}) {
       return segment
     })
     .then((data) => {
-      if (data && data.stream_source_file && data.stream_source_file.meta) {
+      let meta = {}
+      if (data.stream_source_file.meta) {
         try {
-          const parsedMeta = JSON.parse(data.stream_source_file.meta)
-          parsedMeta.filename = data.stream_source_file.filename
-          data.stream_source_file.meta = JSON.stringify(parsedMeta)
+          meta = JSON.parse(data.stream_source_file.meta)
         } catch (err) {
           console.error(err)
         }
       }
+      meta.filename = data.stream_source_file.filename
+      data.stream_source_file.meta = JSON.stringify(meta)
       return {
         site_external_id: data.stream_id,
         uri: getSegmentRemotePath(data), // !!!


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves _bug not in jira_
- [x] API docs na
- [x] Release notes na
- [x] Deployment notes na
- [x] Unit or integration tests na
- [x] DB migrations na

## 📝 Summary

- [Untested] Proposed solution for the meta missing filename for files coming from Guardian via Uploader
