### PR TITLE
Fix /internal/ai-hub/detections return all streams from projects if…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.24-hotfix.1 (2021-??-??)
+
+### Bug Fixes
+* **internal:** Fix /internal/ai-hub/detections return all streams from projects if projects were given
+
 ## 1.0.24 (2021-08-24)
 
 ### Features

--- a/services/detections/reviews.js
+++ b/services/detections/reviews.js
@@ -35,24 +35,20 @@ async function getConditionsAndBind (options, start, end, streams, projects, cla
   const projectsAndStreamsConditions = []
 
   /**
-   * If there are projects given, check if the user has permission or has a special role e.g. super, system.
+   * Check if the user has permission or has a special role e.g. super, system.
    * If it is a normal user, check the projects by permission.
    * If it is a special role user, allow every projects.
    */
-  if (projects) {
-    projectsAndStreamsConditions.push('s.project_id = ANY($projects)')
-    bind.projects = readableBy === undefined ? projects : await getAccessibleObjectsIDs(readableBy, PROJECT, projects, 'R', true)
-  }
-
   if (streams) {
     projectsAndStreamsConditions.push('d.stream_id = ANY($streams)')
     bind.streams = readableBy === undefined ? streams : await getAccessibleObjectsIDs(readableBy, STREAM, streams, 'R', true)
-  }
-
-  /**
-   * If no streams and no projects given, then get public streams and user allowed permission streams
-   */
-  if (!streams && !projects) {
+  } else if (projects) {
+    projectsAndStreamsConditions.push('s.project_id = ANY($projects)')
+    bind.projects = readableBy === undefined ? projects : await getAccessibleObjectsIDs(readableBy, PROJECT, projects, 'R', true)
+  } else {
+    /**
+     * If no streams and no projects given, then get public streams and user allowed permission streams
+     */
     const filteredStreams = await streamServices.query({}, { permissableBy: readableBy })
     conditions.push('s.is_public = true')
     projectsAndStreamsConditions.push('d.stream_id = ANY($streams)')


### PR DESCRIPTION
… projects were given

## ✅ DoD

- [x] Resolves /internal/ai-hub/detections return all streams from projects if projects were given
- [x] API docs na
- [x] Release notes updated
- [x] Deployment notes na
- [x] Unit or integration tests na
- [x] DB migrations na

## 📝 Summary

- Fix /internal/ai-hub/detections return all streams from projects if projects were given

## 📸 Examples

Without stream given with project
![image](https://user-images.githubusercontent.com/44169425/133121171-8198cc85-1d8a-40be-8ee2-a0286dbca728.png)

With stream given with project
![image](https://user-images.githubusercontent.com/44169425/133121311-3bab42f0-30b9-4d92-be3d-4851a45d291f.png)

## 🛑 Problems

- This is a hot fix version of review data proper updated endpoint should be this PR #227 

## 💡 More ideas

None
