### PR TITLE
Guardians should not update automatically by default

### DIFF
--- a/models/guardian.js
+++ b/models/guardian.js
@@ -49,7 +49,7 @@ module.exports = function (sequelize, DataTypes) {
     },
     is_updatable: {
       type: DataTypes.BOOLEAN,
-      defaultValue: true,
+      defaultValue: false,
       validate: {
       }
     },


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves _none_
- [x] API docs na
- [x] Release notes na
- [x] Deployment notes na
- [x] Unit or integration tests na
- [x] DB migrations na

## 📝 Summary

- We accidentally updated some PR Guardians recently. Making the is_updatable flag false by default (in model and table) should stop this happening again.
- Change made in database immediately to avoid it happening again (production and staging), and also set all existing Guardians to not be updatable at the current time.

## 📸 Examples

Put screenshots or response/request examples here!

## 🛑 Problems

- Write any discovered & unresolved problems (link to created Jira issues)

## 💡 More ideas

Write any more ideas you have
