### PR TITLE
Fix download classifier permission

### DIFF
--- a/core/classifiers/dao/index.js
+++ b/core/classifiers/dao/index.js
@@ -43,7 +43,7 @@ async function get (id, options = {}) {
   const query = { where: { id }, raw: true }
 
   if (options.attributes) {
-    query.attributes = options.attributes
+    query.attributes = ['isPublic', 'createdById', ...options.attributes]
   }
 
   const classifier = await models.Classifier.findOne(query)

--- a/core/classifiers/download.js
+++ b/core/classifiers/download.js
@@ -30,9 +30,9 @@ module.exports = (req, res) => {
   const readableBy = user && (user.is_super || user.has_system_role) ? undefined : user.id
   const classifierId = req.params.id
 
-  return get(classifierId, { attributes: ['model_url'], readableBy })
+  return get(classifierId, { attributes: ['modelUrl'], readableBy })
     .then(async (classifier) => {
-      const classifierUrl = classifier.model_url
+      const classifierUrl = classifier.modelUrl
       const signedUrl = await getSignedUrl(classifierUrl)
 
       res.redirect(signedUrl)


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves #XXX
- [x] API docs na
- [x] Release notes na
- [x] Deployment notes na
- [x] Unit or integration tests na
- [x] DB migrations na

_(use na when API docs (Release notes, etc) do not need to be updated)_

## 📝 Summary

- Add `isPublic` and `createdById` when classifier query with custom attribute
- Update `model_url` to `modelUrl`

## 📸 Examples

The user who are not owner request for public classifier:
![image](https://user-images.githubusercontent.com/44169425/191689436-81f19855-bcd9-467d-92dc-1e05de200132.png)

The user who are not owner request for private classifier:
![image](https://user-images.githubusercontent.com/44169425/191689823-d3369c0a-d9f4-46a6-b8f7-039ae85ebabc.png)


## 🛑 Problems

-

## 💡 More ideas

-