### PR TITLE
Add an include to return version of classifier back

### DIFF
--- a/core/classifier-jobs/dao/index.js
+++ b/core/classifier-jobs/dao/index.js
@@ -6,7 +6,7 @@ const pagedQuery = require('../../_utils/db/paged-query')
 const { toCamelObject } = require('../../_utils/formatters/string-cases')
 
 const availableIncludes = [
-  Classifier.include({ attributes: ['id', 'name'] }),
+  Classifier.include({ attributes: ['id', 'name', 'version'] }),
   // `through: { attributes: [] }` is required to delete `classifier_job_streams: { ClassifierJobId: id, StreamId: id }` from result
   Stream.include({ as: 'streams', attributes: ['id', 'name'], required: false, through: { attributes: [] } })
 ]


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves #476 
- [ ] API docs updated na
- [ ] Release notes updated na
- [ ] Deployment notes updated na
- [ ] Unit or integration tests added na
- [ ] DB migrations tested na

_(use na when API docs (Release notes, etc) do not need to be updated)_

## 📝 Summary

- Include `version` column in classifier include for `GET /classifier-jobs/:id`

## 📸 Examples

- none

## 🛑 Problems

- none

## 💡 More ideas

Write any more ideas you have
