### PR TITLE
Fix project creation failed with user is super

### DIFF
--- a/core/projects/bl/index.js
+++ b/core/projects/bl/index.js
@@ -61,7 +61,6 @@ async function create (params, options = {}) {
 
   const project = {
     ...params,
-    createdById: options.creatableById,
     id: randomId()
   }
 

--- a/core/projects/create.js
+++ b/core/projects/create.js
@@ -48,7 +48,10 @@ module.exports = (req, res) => {
   converter.convert('external_id').optional().toInt()
 
   return converter.validate()
-    .then((params) => create(params, options))
+    .then((params) => {
+      params.createdById = user.id
+      return create(params, options)
+    })
     .then(project => res.location(`/projects/${project.id}`).sendStatus(201))
     .catch(httpErrorHandler(req, res, 'Failed creating project'))
 }


### PR DESCRIPTION
- add `user_id` in params as `createdById` for spread object
- not use `creatableById` as `createdById`