### PR TITLE
fix: config should set environment before requiring sequelize

### DIFF
--- a/core/main.js
+++ b/core/main.js
@@ -1,12 +1,14 @@
 console.info('info: Core: Starting...')
 const startTime = new Date()
-const { sequelize } = require('./_models')
 
 // Handle unhandled promises
 require('../common/error-handling/process')
 
 // Check required env vars are set
 require('../common/config')
+
+// must initialize config before requiring sequelize
+const { sequelize } = require('./_models')
 
 const winston = require('winston')
 // Load application


### PR DESCRIPTION
## ✅ DoD

- [x] Fixes bug when we use env_vars.js (!!)
- [ ] API docs updated na
- [ ] Release notes updated na
- [ ] Deployment notes updated na
- [ ] Unit or integration tests added na
- [ ] DB migrations tested na

_(use na when API docs (Release notes, etc) do not need to be updated)_

## 🛑 Problems

env-vars are set in common/config/index.js, so sequelize must be imported only after config. Because modules are singletons and are created only once