### PR TITLE
Throw error site id missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 * **core**: Endpoint `POST /streams/:streamId/detections/:start/review` now returns the review status and id of the detection that has been reviewed in the call.
 * **core**: Create unique constraint of `(detection_id, user_id)` inside `detection_reviews` table.
 
+### Bug Fixes
+* **core**: Throw an error if stream from Arbimon site creation missing `site_id`
+
 ## 1.3.12 (2024-05-30)
 ### Common
 * **core**: Remove `jwt-custom` and merge custom into list

--- a/core/streams/bl/index.js
+++ b/core/streams/bl/index.js
@@ -50,6 +50,9 @@ async function create (params, options = {}) {
     try {
       const arbimonSite = { ...fullStream, country_code: fullStream.countryCode }
       const externalSite = await arbimonService.createSite(arbimonSite, options.idToken)
+      if (!externalSite.site_id) {
+        throw new Error('site_id is missing in Arbimon stream creation response')
+      }
       fullStream.externalId = externalSite.site_id
     } catch (error) {
       console.error(`Error creating site in Arbimon (stream: ${fullStream.id})`)


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves #628 
- [x] Release notes updated na

_(use na when API docs (Release notes, etc) do not need to be updated)_

## 📝 Summary

- Throw an error if stream from Arbimon site creation missing `site_id`
