### PR TITLE
feat: find best_detections for classifications (#631)

### DIFF
--- a/core/_cli/migrations/20240404131807-create-best-detections.ts.js
+++ b/core/_cli/migrations/20240404131807-create-best-detections.ts.js
@@ -56,46 +56,47 @@ module.exports = {
         )
       `, { transaction: t })
 
-      const jobs = await queryInterface.sequelize.query('select "id", "query_start", "query_end" from public.classifier_jobs', {
-        transaction: t,
-        type: Sequelize.QueryTypes.SELECT,
-        raw: true
-      })
+      // NOT USED SINCE IT'S rewritten in the next migration
+      // const jobs = await queryInterface.sequelize.query('select "id", "query_start", "query_end" from public.classifier_jobs', {
+      //   transaction: t,
+      //   type: Sequelize.QueryTypes.SELECT,
+      //   raw: true
+      // })
 
-      for (const job of jobs) {
-        const replacements = {
-          classifierJobId: job.id,
-          perDayLimit: 10,
-          perStreamLimit: 10,
-          jobStart: job.query_start,
-          jobEnd: job.query_end
-        }
+      // for (const job of jobs) {
+      //   const replacements = {
+      //     classifierJobId: job.id,
+      //     perDayLimit: 10,
+      //     perStreamLimit: 10,
+      //     jobStart: job.query_start,
+      //     jobEnd: job.query_end
+      //   }
 
-        await queryInterface.sequelize.query(`
-          INSERT INTO public.best_detections
-          SELECT
-          "detection_id", "start", "stream_id", "classifier_job_id", "confidence", "daily_ranking", "stream_ranking"
-            FROM (
-              SELECT
-              "id" as "detection_id", "start", "stream_id", "classifier_job_id", "confidence",
-              ROW_NUMBER() OVER(
-                PARTITION BY stream_id, date(timezone('UTC',  "start"))
-                ORDER BY confidence DESC
-              ) as daily_ranking,
-              ROW_NUMBER() OVER(
-                PARTITION BY stream_id
-                ORDER BY confidence DESC
-              ) as stream_ranking
-              FROM public.detections
-              WHERE (start BETWEEN :jobStart AND :jobEnd) AND classifier_job_id = :classifierJobId
-            ) as detection
-          WHERE daily_ranking < :perDayLimit OR stream_ranking < :perStreamLimit;
-        `, {
-          replacements,
-          type: Sequelize.QueryTypes.RAW,
-          transaction: t
-        })
-      }
+      //   await queryInterface.sequelize.query(`
+      //     INSERT INTO public.best_detections
+      //     SELECT
+      //     "detection_id", "start", "stream_id", "classifier_job_id", "confidence", "daily_ranking", "stream_ranking"
+      //       FROM (
+      //         SELECT
+      //         "id" as "detection_id", "start", "stream_id", "classifier_job_id", "confidence",
+      //         ROW_NUMBER() OVER(
+      //           PARTITION BY stream_id, date(timezone('UTC',  "start"))
+      //           ORDER BY confidence DESC
+      //         ) as daily_ranking,
+      //         ROW_NUMBER() OVER(
+      //           PARTITION BY stream_id
+      //           ORDER BY confidence DESC
+      //         ) as stream_ranking
+      //         FROM public.detections
+      //         WHERE (start BETWEEN :jobStart AND :jobEnd) AND classifier_job_id = :classifierJobId
+      //       ) as detection
+      //     WHERE daily_ranking < :perDayLimit OR stream_ranking < :perStreamLimit;
+      //   `, {
+      //     replacements,
+      //     type: Sequelize.QueryTypes.RAW,
+      //     transaction: t
+      //   })
+      // }
     })
   },
   down: async (queryInterface) => {

--- a/core/_cli/migrations/20240404131807-create-best-detections.ts.js
+++ b/core/_cli/migrations/20240404131807-create-best-detections.ts.js
@@ -55,48 +55,6 @@ module.exports = {
           detection_id ASC NULLS LAST
         )
       `, { transaction: t })
-
-      // NOT USED SINCE IT'S rewritten in the next migration
-      // const jobs = await queryInterface.sequelize.query('select "id", "query_start", "query_end" from public.classifier_jobs', {
-      //   transaction: t,
-      //   type: Sequelize.QueryTypes.SELECT,
-      //   raw: true
-      // })
-
-      // for (const job of jobs) {
-      //   const replacements = {
-      //     classifierJobId: job.id,
-      //     perDayLimit: 10,
-      //     perStreamLimit: 10,
-      //     jobStart: job.query_start,
-      //     jobEnd: job.query_end
-      //   }
-
-      //   await queryInterface.sequelize.query(`
-      //     INSERT INTO public.best_detections
-      //     SELECT
-      //     "detection_id", "start", "stream_id", "classifier_job_id", "confidence", "daily_ranking", "stream_ranking"
-      //       FROM (
-      //         SELECT
-      //         "id" as "detection_id", "start", "stream_id", "classifier_job_id", "confidence",
-      //         ROW_NUMBER() OVER(
-      //           PARTITION BY stream_id, date(timezone('UTC',  "start"))
-      //           ORDER BY confidence DESC
-      //         ) as daily_ranking,
-      //         ROW_NUMBER() OVER(
-      //           PARTITION BY stream_id
-      //           ORDER BY confidence DESC
-      //         ) as stream_ranking
-      //         FROM public.detections
-      //         WHERE (start BETWEEN :jobStart AND :jobEnd) AND classifier_job_id = :classifierJobId
-      //       ) as detection
-      //     WHERE daily_ranking < :perDayLimit OR stream_ranking < :perStreamLimit;
-      //   `, {
-      //     replacements,
-      //     type: Sequelize.QueryTypes.RAW,
-      //     transaction: t
-      //   })
-      // }
     })
   },
   down: async (queryInterface) => {

--- a/core/_cli/migrations/20240613065719-best-detections-for-species.js
+++ b/core/_cli/migrations/20240613065719-best-detections-for-species.js
@@ -1,0 +1,143 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async t => {
+      await queryInterface.sequelize.query('DELETE FROM public."best_detections"', {
+        transaction: t
+      })
+
+      await queryInterface.addColumn(
+        'best_detections',
+        'classification_id',
+        {
+          type: Sequelize.INTEGER,
+          allowNull: false,
+          references: {
+            model: {
+              tableName: 'classifications'
+            },
+            key: 'id'
+          }
+        },
+        { transaction: t }
+      )
+      await queryInterface.renameColumn(
+        'best_detections',
+        'daily_ranking',
+        'stream_daily_ranking',
+        { transaction: t }
+      )
+      await queryInterface.addColumn(
+        'best_detections',
+        'stream_classification_ranking',
+        {
+          type: Sequelize.INTEGER,
+          allowNull: false
+        },
+        { transaction: t }
+      )
+      await queryInterface.addColumn(
+        'best_detections',
+        'stream_classification_daily_ranking',
+        {
+          type: Sequelize.INTEGER,
+          allowNull: false
+        },
+        { transaction: t }
+      )
+
+      const jobs = await queryInterface.sequelize.query('select "id", "query_start", "query_end" from public.classifier_jobs', {
+        transaction: t,
+        type: Sequelize.QueryTypes.SELECT,
+        raw: true
+      })
+
+      for (const job of jobs) {
+        const replacements = {
+          classifierJobId: job.id,
+          dayLimit: 10,
+          limit: 10,
+          streamClassificationDayLimit: 5,
+          jobStart: job.query_start,
+          jobEnd: job.query_end
+        }
+
+        await queryInterface.sequelize.query(`
+          INSERT INTO public.best_detections
+          (
+            "detection_id",
+            "start", "stream_id", "classifier_job_id", "confidence", "classification_id",
+            "stream_ranking",
+            "stream_daily_ranking",
+            "stream_classification_ranking",
+            "stream_classification_daily_ranking"
+          )
+          SELECT
+            "detection_id",
+            "start", "stream_id", "classifier_job_id", "confidence", "classification_id"
+            "stream_ranking",
+            "stream_daily_ranking",
+            "stream_classification_ranking",
+            "stream_classification_daily_ranking",
+          FROM (
+              SELECT
+              "id" as "detection_id",
+              "start", "stream_id", "classifier_job_id", "confidence", "classification_id",
+              ROW_NUMBER() OVER(
+                PARTITION BY stream_id
+                ORDER BY confidence DESC
+              ) as stream_ranking,
+              ROW_NUMBER() OVER(
+                PARTITION BY stream_id, date(timezone('UTC',  "start"))
+                ORDER BY confidence DESC
+              ) as stream_daily_ranking,
+              ROW_NUMBER() OVER(
+                PARTITION BY stream_id, classification_id
+                ORDER BY confidence DESC
+              ) as stream_classification_ranking,
+              ROW_NUMBER() OVER(
+                PARTITION BY stream_id, classification_id, date(timezone('UTC',  "start"))
+                ORDER BY confidence DESC
+              ) as stream_classification_daily_ranking
+              FROM public.detections
+              WHERE (start BETWEEN :jobStart AND :jobEnd) AND classifier_job_id = :classifierJobId
+            ) as detection
+          WHERE stream_ranking < :limit OR stream_classification_ranking < :limit OR
+                stream_daily_ranking < :dayLimit OR
+                stream_classification_daily_ranking < :streamClassificationDayLimit;`,
+        {
+          replacements,
+          type: Sequelize.QueryTypes.RAW,
+          transaction: t
+        })
+      }
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(async t => {
+      await queryInterface.removeColumn(
+        'best_detections',
+        'classification_id',
+        { transaction: t }
+      )
+      await queryInterface.renameColumn(
+        'best_detections',
+        'stream_daily_ranking',
+        'daily_ranking',
+        { transaction: t }
+      )
+      await queryInterface.removeColumn(
+        'best_detections',
+        'stream_classification_ranking',
+        { transaction: t }
+      )
+      await queryInterface.removeColumn(
+        'best_detections',
+        'stream_classification_daily_ranking',
+        { transaction: t }
+      )
+    })
+  }
+}

--- a/core/_models/detections/best-detection.js
+++ b/core/_models/detections/best-detection.js
@@ -21,11 +21,23 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.FLOAT,
       allowNull: false
     },
-    dailyRanking: {
+    classificationId: {
+      type: DataTypes.INTEGER,
+      allowNull: true
+    },
+    streamRanking: {
       type: DataTypes.INTEGER,
       allowNull: false
     },
-    streamRanking: {
+    streamDailyRanking: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    },
+    streamClassificationRanking: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    },
+    streamClassificationDailyRanking: {
       type: DataTypes.INTEGER,
       allowNull: false
     }
@@ -36,6 +48,7 @@ module.exports = (sequelize, DataTypes) => {
   BestDetection.associate = function (models) {
     BestDetection.belongsTo(models.Detection, { as: 'detection', foreignKey: 'detection_id' })
     BestDetection.belongsTo(models.ClassifierJob, { as: 'classifier_job', foreignKey: 'classifier_job_id' })
+    BestDetection.belongsTo(models.Classification, { as: 'classification', foreignKey: 'classification_id' })
   }
   return BestDetection
 }

--- a/core/_models/detections/detection.js
+++ b/core/_models/detections/detection.js
@@ -41,7 +41,7 @@ module.exports = (sequelize, DataTypes) => {
     Detection.hasOne(models.BestDetection, { as: 'bestDetection', foreignKey: 'detection_id' })
   }
   Detection.attributes = {
-    lite: ['stream_id', 'start', 'end', 'confidence'],
+    lite: ['id', 'stream_id', 'start', 'end', 'confidence'], // VERY SCARY CHANGE
     full: ['id', 'stream_id', 'classifier_id', 'classification_id', 'classifier_job_id', 'start', 'end', 'confidence', 'review_status']
   }
   return Detection

--- a/core/_models/detections/detection.js
+++ b/core/_models/detections/detection.js
@@ -41,7 +41,7 @@ module.exports = (sequelize, DataTypes) => {
     Detection.hasOne(models.BestDetection, { as: 'bestDetection', foreignKey: 'detection_id' })
   }
   Detection.attributes = {
-    lite: ['id', 'stream_id', 'start', 'end', 'confidence'], // VERY SCARY CHANGE
+    lite: ['id', 'stream_id', 'start', 'end', 'confidence'],
     full: ['id', 'stream_id', 'classifier_id', 'classification_id', 'classifier_job_id', 'start', 'end', 'confidence', 'review_status']
   }
   return Detection

--- a/core/detections/best-detections-summary.js
+++ b/core/detections/best-detections-summary.js
@@ -20,6 +20,24 @@ const dao = require('./dao')
  *         schema:
  *           type: string
  *         example: 100
+ *       - name: streams
+ *         description: Find best results for a given stream ids
+ *         in: query
+ *         required: false
+ *         schema:
+ *           type: array
+ *           items:
+ *             type: string
+ *         example: ['x9ekbilso331']
+ *       - name: classifications
+ *         description: Find best results for a given classification ids
+ *         in: query
+ *         required: false
+ *         schema:
+ *           type: array
+ *           items:
+ *             type: string
+ *         example: [3,4,5]
  *       - name: by_date
  *         description: Find best detections per each date (instead of whole period)
  *         in: query
@@ -54,7 +72,7 @@ const dao = require('./dao')
  *           items:
  *             type: string
  *         example: [unreviewed, rejected]
- *       - name: n_per_stream
+ *       - name: n_per_chunk
  *         description: Maximum number of results per stream (and per day if `by_date` is set to `true`)
  *         in: query
  *         required: false
@@ -64,16 +82,6 @@ const dao = require('./dao')
  *           minimum: 1
  *           maximum: 10
  *         default: 1
- *       - name: streams
- *         description: Limit response results to a given stream ids
- *         in: query
- *         required: false
- *         schema:
- *           type: array
- *           items:
- *             type: string
- *         example: ['x9ekbilso331']
- *
  *     responses:
  *       200:
  *         description: Object with parameters of each review status with their counts by given filters.
@@ -92,11 +100,12 @@ router.get('/:jobId/best-detections/summary', (req, res) => {
   const { jobId } = req.params
   const converter = new Converter(req.query, {}, true)
   converter.convert('streams').optional().toArray()
+  converter.convert('classifications').optional().toArray()
   converter.convert('by_date').default(false).toBoolean()
   converter.convert('start').optional().toMomentUtc()
   converter.convert('end').optional().toMomentUtc()
   converter.convert('review_statuses').optional().toArray()
-  converter.convert('n_per_stream').default(1).toInt().maximum(10)
+  converter.convert('n_per_chunk').default(1).toInt().maximum(10)
 
   return converter.validate().then(async (filters) => {
     filters.classifierJobId = jobId

--- a/core/detections/best-detections-summary.js
+++ b/core/detections/best-detections-summary.js
@@ -29,7 +29,7 @@ const dao = require('./dao')
  *           items:
  *             type: string
  *         example: ['x9ekbilso331']
- *       - name: classifications
+ *       - name: classification_ids
  *         description: Find best results for a given classification ids
  *         in: query
  *         required: false
@@ -100,7 +100,7 @@ router.get('/:jobId/best-detections/summary', (req, res) => {
   const { jobId } = req.params
   const converter = new Converter(req.query, {}, true)
   converter.convert('streams').optional().toArray()
-  converter.convert('classifications').optional().toArray()
+  converter.convert('classification_ids').optional().toArray()
   converter.convert('by_date').default(false).toBoolean()
   converter.convert('start').optional().toMomentUtc()
   converter.convert('end').optional().toMomentUtc()

--- a/core/detections/best-detections.int.test.js
+++ b/core/detections/best-detections.int.test.js
@@ -238,7 +238,7 @@ test('should respect streams and classifications in best per day', async () => {
     start: '2024-01-01T00:00:00.000Z',
     end: '2024-01-04T00:00:00.000Z',
     streams: [streams[0].id, streams[1].id],
-    classifications: [classifications[1].id]
+    classification_ids: [classifications[1].id]
   }
 
   const response = await request(app).get(`/${classifierJobs[0].id}/best-detections`).query(query)
@@ -282,7 +282,7 @@ test('should respect classifications in best per stream', async () => {
   const query = {
     by_date: false,
     n_per_chunk: 2,
-    classifications: [classifications[0].id]
+    classification_ids: [classifications[0].id]
   }
 
   const response = await request(app).get(`/${classifierJobs[0].id}/best-detections`).query(query)

--- a/core/detections/best-detections.js
+++ b/core/detections/best-detections.js
@@ -22,7 +22,7 @@ const Converter = require('../../common/converter')
  *         description: List of stream ids to limit results
  *         in: query
  *         type: array|string
- *       - name: classifications
+ *       - name: classification_ids
  *         description: Find best results for a given classification ids
  *         in: query
  *         required: false
@@ -92,7 +92,7 @@ router.get('/:jobId/best-detections', (req, res) => {
   const { jobId } = req.params
   const converter = new Converter(req.query, {}, true)
   converter.convert('streams').optional().toArray()
-  converter.convert('classifications').optional().toArray()
+  converter.convert('classification_ids').optional().toArray()
   converter.convert('by_date').default(false).toBoolean()
   converter.convert('start').optional().toMomentUtc()
   converter.convert('end').optional().toMomentUtc()

--- a/core/detections/bl/best-detections.int.test.js
+++ b/core/detections/bl/best-detections.int.test.js
@@ -40,7 +40,7 @@ beforeAll(async () => {
   classifierJobs = await models.ClassifierJob.bulkCreate(classifierJobs)
 })
 
-function detectionFactory (partialDetection) {
+function oneDetection (partialDetection) {
   return {
     streamId: streams[0].id,
     classifierId: classifiers[0].id,
@@ -55,24 +55,24 @@ function detectionFactory (partialDetection) {
 test('should rank daily jobs of 1 stream in right order', async () => {
   const detections = [
     // day 1
-    detectionFactory({
+    oneDetection({
       start: new Date('2024-01-01T09:00:00.000Z'),
       confidence: 0.82
     }),
-    detectionFactory({
+    oneDetection({
       start: new Date('2024-01-01T11:00:00.000Z'),
       confidence: 0.95
     }),
-    detectionFactory({
+    oneDetection({
       start: new Date('2024-01-01T12:00:00.000Z'),
       confidence: 0.87
     }),
     // day2
-    detectionFactory({
+    oneDetection({
       start: new Date('2024-01-02T12:00:00.000Z'),
       confidence: 0.93
     }),
-    detectionFactory({
+    oneDetection({
       start: new Date('2024-01-02T12:00:00.000Z'),
       confidence: 0.88
     })
@@ -86,11 +86,11 @@ test('should rank daily jobs of 1 stream in right order', async () => {
     order: ['start']
   })
 
-  expect(found[0].dailyRanking).toBe(3)
-  expect(found[1].dailyRanking).toBe(1)
-  expect(found[2].dailyRanking).toBe(2)
-  expect(found[3].dailyRanking).toBe(1)
-  expect(found[4].dailyRanking).toBe(2)
+  expect(found[0].streamDailyRanking).toBe(3)
+  expect(found[1].streamDailyRanking).toBe(1)
+  expect(found[2].streamDailyRanking).toBe(2)
+  expect(found[3].streamDailyRanking).toBe(1)
+  expect(found[4].streamDailyRanking).toBe(2)
 
   expect(found[0].streamRanking).toBe(5)
   expect(found[1].streamRanking).toBe(1)
@@ -99,28 +99,91 @@ test('should rank daily jobs of 1 stream in right order', async () => {
   expect(found[4].streamRanking).toBe(3)
 })
 
-test('should rank detections from only one job', async () => {
+test('should rank stream job of 1 stream but 2 species in right order', async () => {
+  const detections = [
+    // day 1
+    oneDetection({ // 4th best woodpecker (2nd of that day)
+      start: new Date('2024-01-01T09:00:00.000Z'),
+      classification_id: classifications[0].id,
+      confidence: 0.82
+    }),
+    oneDetection({ // 3rd best woodpecker (1st of that day)
+      start: new Date('2024-01-01T09:30:00.000Z'),
+      classification_id: classifications[0].id,
+      confidence: 0.87
+    }),
+    oneDetection({ // 1st best frog
+      start: new Date('2024-01-01T11:00:00.000Z'),
+      classification_id: classifications[1].id,
+      confidence: 0.95
+    }),
+    // day2
+    oneDetection({ // 1st best woodpecker (1st of that day)
+      start: new Date('2024-01-02T12:00:00.000Z'),
+      classification_id: classifications[0].id,
+      confidence: 0.93
+    }),
+    oneDetection({ // 2nd best frog (1st of day)
+      start: new Date('2024-01-02T12:30:00.000Z'),
+      classification_id: classifications[1].id,
+      confidence: 0.88
+    }),
+    oneDetection({ // 2nd best woodpecker (2nd of that day)
+      start: new Date('2024-01-02T12:50:00.000Z'),
+      classification_id: classifications[0].id,
+      confidence: 0.91
+    })
+  ]
+
+  await models.Detection.bulkCreate(detections)
+  await updateBestDetections(classifierJobs[0])
+
+  const found = await models.BestDetection.findAll({
+    where: { classifierJobId: classifierJobs[0].id },
+    order: ['start']
+  })
+
+  expect(found[0].streamClassificationRanking).toBe(4)
+  expect(found[0].streamClassificationDailyRanking).toBe(2)
+
+  expect(found[1].streamClassificationRanking).toBe(3)
+  expect(found[1].streamClassificationDailyRanking).toBe(1)
+
+  expect(found[2].streamClassificationRanking).toBe(1)
+  expect(found[2].streamClassificationDailyRanking).toBe(1)
+
+  expect(found[3].streamClassificationRanking).toBe(1)
+  expect(found[3].streamClassificationDailyRanking).toBe(1)
+
+  expect(found[4].streamClassificationRanking).toBe(2)
+  expect(found[4].streamClassificationDailyRanking).toBe(1)
+
+  expect(found[5].streamClassificationRanking).toBe(2)
+  expect(found[5].streamClassificationDailyRanking).toBe(2)
+})
+
+test('should rank detections by stream from only one job', async () => {
   const detections = [
     // job1 1
-    detectionFactory({
+    oneDetection({
       start: new Date('2024-01-01T09:00:00.000Z'),
       confidence: 0.82
     }),
-    detectionFactory({
+    oneDetection({
       start: new Date('2024-01-01T11:00:00.000Z'),
       confidence: 0.95
     }),
-    detectionFactory({
+    oneDetection({
       start: new Date('2024-01-01T12:00:00.000Z'),
       confidence: 0.87
     }),
     // job 2
-    detectionFactory({
+    oneDetection({
       start: new Date('2024-01-01T13:00:00.000Z'),
       classifierJobId: classifierJobs[1].id,
       confidence: 0.82
     }),
-    detectionFactory({
+    oneDetection({
       start: new Date('2024-01-01T14:00:00.000Z'),
       classifierJobId: classifierJobs[1].id,
       confidence: 0.95
@@ -145,32 +208,32 @@ test('should rank detections from only one job', async () => {
 test('should rank daily detections of different streams independently', async () => {
   const detections = [
     // stream 1
-    detectionFactory({
+    oneDetection({
       start: new Date('2024-01-01T09:00:00.000Z'),
       confidence: 0.82
     }),
-    detectionFactory({
+    oneDetection({
       start: new Date('2024-01-01T11:00:00.000Z'),
       confidence: 0.95
     }),
     // stream 2
-    detectionFactory({
+    oneDetection({
       start: new Date('2024-01-01T09:01:00.000Z'),
       streamId: streams[1].id,
       confidence: 0.83
     }),
-    detectionFactory({
+    oneDetection({
       start: new Date('2024-01-01T10:01:00.000Z'),
       streamId: streams[1].id,
       confidence: 0.94
     }),
     // stream 3
-    detectionFactory({
+    oneDetection({
       start: new Date('2024-01-01T09:05:00.000Z'),
       streamId: streams[2].id,
       confidence: 0.96
     }),
-    detectionFactory({
+    oneDetection({
       start: new Date('2024-01-01T11:05:00.000Z'),
       streamId: streams[2].id,
       confidence: 0.77
@@ -188,51 +251,51 @@ test('should rank daily detections of different streams independently', async ()
   expect(found).toHaveLength(6)
 
   expect(found[0].streamId).toBe(streams[0].id)
-  expect(found[0].dailyRanking).toBe(2)
+  expect(found[0].streamDailyRanking).toBe(2)
 
   expect(found[1].streamId).toBe(streams[0].id)
-  expect(found[1].dailyRanking).toBe(1)
+  expect(found[1].streamDailyRanking).toBe(1)
 
   expect(found[2].streamId).toBe(streams[1].id)
-  expect(found[2].dailyRanking).toBe(2)
+  expect(found[2].streamDailyRanking).toBe(2)
 
   expect(found[3].streamId).toBe(streams[1].id)
-  expect(found[3].dailyRanking).toBe(1)
+  expect(found[3].streamDailyRanking).toBe(1)
 
   expect(found[4].streamId).toBe(streams[2].id)
-  expect(found[4].dailyRanking).toBe(1)
+  expect(found[4].streamDailyRanking).toBe(1)
 
   expect(found[5].streamId).toBe(streams[2].id)
-  expect(found[5].dailyRanking).toBe(2)
+  expect(found[5].streamDailyRanking).toBe(2)
 })
 
 test('should rank stream detections of different streams independently', async () => {
   const detections = [
     // stream 1
-    detectionFactory({
+    oneDetection({
       start: new Date('2024-01-01T09:00:00.000Z'),
       confidence: 0.93
     }),
-    detectionFactory({
+    oneDetection({
       start: new Date('2024-01-02T11:00:00.000Z'),
       confidence: 0.88
     }),
-    detectionFactory({
+    oneDetection({
       start: new Date('2024-01-02T12:00:00.000Z'),
       confidence: 0.95
     }),
     // stream 2
-    detectionFactory({
+    oneDetection({
       start: new Date('2024-01-01T09:01:00.000Z'),
       streamId: streams[1].id,
       confidence: 0.97
     }),
-    detectionFactory({
+    oneDetection({
       start: new Date('2024-01-01T11:01:00.000Z'),
       streamId: streams[1].id,
       confidence: 0.83
     }),
-    detectionFactory({
+    oneDetection({
       start: new Date('2024-01-01T12:01:00.000Z'),
       streamId: streams[1].id,
       confidence: 0.94

--- a/core/detections/dao/best-detections.js
+++ b/core/detections/dao/best-detections.js
@@ -2,6 +2,7 @@ const { BestDetection, sequelize } = require('../../_models')
 
 const BEST_ITEMS_PER_DAY_STREAM_LIMIT = 10
 const BEST_ITEMS_PER_STREAM_LIMIT = 10
+const BEST_ITEMS_PER_STREAM_CLASSIFICATION_DAY = 5
 
 module.exports.dropBestDetections = async function dropBestDetections (classifierJob) {
   const where = { classifierJobId: classifierJob.id }
@@ -11,32 +12,58 @@ module.exports.dropBestDetections = async function dropBestDetections (classifie
 module.exports.saveBestDetections = async function cacheBestDetections (classifierJob) {
   const replacements = {
     classifierJobId: classifierJob.id,
-    perDayLimit: BEST_ITEMS_PER_DAY_STREAM_LIMIT,
-    perStreamLimit: BEST_ITEMS_PER_STREAM_LIMIT,
+    dayLimit: BEST_ITEMS_PER_DAY_STREAM_LIMIT,
+    limit: BEST_ITEMS_PER_STREAM_LIMIT,
+    streamClassificationDayLimit: BEST_ITEMS_PER_STREAM_CLASSIFICATION_DAY,
     jobStart: classifierJob.queryStart,
     jobEnd: classifierJob.queryEnd
   }
 
   await sequelize.query(`
     INSERT INTO public.best_detections
+    (
+      "detection_id",
+      "start", "stream_id", "classifier_job_id", "confidence", "classification_id",
+      "stream_ranking",
+      "stream_daily_ranking",
+      "stream_classification_ranking",
+      "stream_classification_daily_ranking"
+    )
     SELECT
-    "detection_id", "start", "stream_id", "classifier_job_id", "confidence", "daily_ranking", "stream_ranking"
-      FROM (
+      "detection_id",
+      "start", "stream_id", "classifier_job_id", "confidence", "classification_id",
+      "stream_ranking",
+      "stream_daily_ranking",
+      "stream_classification_ranking",
+      "stream_classification_daily_ranking"
+    FROM (
         SELECT
-        "id" as "detection_id", "start", "stream_id", "classifier_job_id", "confidence",
-        ROW_NUMBER() OVER(
-          PARTITION BY stream_id, date(timezone('UTC',  "start"))
-          ORDER BY confidence DESC
-        ) as daily_ranking,
+        "id" as "detection_id",
+        "start", "stream_id", "classifier_job_id", "confidence", "classification_id",
         ROW_NUMBER() OVER(
           PARTITION BY stream_id
           ORDER BY confidence DESC
-        ) as stream_ranking
+        ) as stream_ranking,
+        ROW_NUMBER() OVER(
+          PARTITION BY stream_id, date(timezone('UTC',  "start"))
+          ORDER BY confidence DESC
+        ) as stream_daily_ranking,
+        ROW_NUMBER() OVER(
+          PARTITION BY stream_id, classification_id
+          ORDER BY confidence DESC
+        ) as stream_classification_ranking,
+        ROW_NUMBER() OVER(
+          PARTITION BY stream_id, classification_id, date(timezone('UTC',  "start"))
+          ORDER BY confidence DESC
+        ) as stream_classification_daily_ranking
         FROM public.detections
         WHERE (start BETWEEN :jobStart AND :jobEnd) AND classifier_job_id = :classifierJobId
       ) as detection
-    WHERE daily_ranking < :perDayLimit OR stream_ranking < :perStreamLimit;
-  `, {
+    WHERE stream_ranking < :limit OR
+          stream_classification_ranking < :limit OR
+          stream_daily_ranking < :dayLimit OR
+          stream_classification_daily_ranking < :streamClassificationDayLimit;`,
+  {
     replacements,
     type: sequelize.QueryTypes.RAW
   })

--- a/core/detections/dao/index.js
+++ b/core/detections/dao/index.js
@@ -90,7 +90,7 @@ async function defaultQueryOptions (filters = {}, options = {}) {
 
 async function defaultBestDetectionsQueryOptions (filters, opts) {
   const { user, limit, offset, fields } = opts
-  const { streams, classifications, reviewStatuses } = filters
+  const { streams, classificationIds, reviewStatuses } = filters
   const where = {}
   const bestDetectionsWhere = { classifierJobId: filters.classifierJobId }
   const attributes = fields && fields.length > 0 ? Detection.attributes.full.filter(a => fields.includes(a)) : Detection.attributes.lite
@@ -121,10 +121,10 @@ async function defaultBestDetectionsQueryOptions (filters, opts) {
   }
 
   let byClassicication = false
-  if (classifications) {
+  if (classificationIds) {
     byClassicication = true
 
-    bestDetectionsWhere.classificationId = classifications
+    bestDetectionsWhere.classificationId = classificationIds
   }
 
   if (reviewStatuses !== undefined) {


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves #631 
- [ ] API docs updated na
- [ ] Release notes updated na
- [ ] Deployment notes updated na
- [ ] Unit or integration tests added na
- [ ] DB migrations tested na

_(use na when API docs (Release notes, etc) do not need to be updated)_

## 📝 Summary

Now when "classifications" query parameter is passed to 
GET /classifier-jobs/{jobId}/best-detections
or
GET /classifier-jobs/{jobId}/best-detections/summary
The returned detections will be related to specific classification_id

## 🛑 Problems

- Write any discovered & unresolved problems (link to created Jira issues)

## 💡 More ideas

Write any more ideas you have
