### PR TITLE
fix: time gap to stop server on SIGTERM

### DIFF
--- a/core/main.js
+++ b/core/main.js
@@ -44,8 +44,14 @@ process.on('uncaughtException', (error) => {
   process.exit(1)
 })
 
-function handle (signal) {
+async function handle (signal) {
   emergencyLogger.error(`Received SIGNAL ${signal}, exiting`)
+
+  // we wait for it here, so that request that transfer data right now
+  // can finish it and not fail
+  await new Promise((resolve) => {
+    setTimeout(resolve, 1500)
+  })
 
   server.close(async (error) => {
     if (error) {


### PR DESCRIPTION
## ✅ DoD

- [ ] API docs updated na
- [ ] Release notes updated na
- [ ] Deployment notes updated na
- [ ] Unit or integration tests added na
- [ ] DB migrations tested na

_(use na when API docs (Release notes, etc) do not need to be updated)_

## 📝 Summary

In the logs there are requests that got ECONNRESET in the moment there API gets SIGTERM signal. And we know that after that there are successful finished requests. So probably requests are reset because they were dialed during the sigterm (their request time is always arount 1-2ms)
So we should allow requests to finish dialling.
And at the same time the pod is excluded from the kubernetes service, so no new requests will come.

## 📸 Examples

Put screenshots or response/request examples here!

## 🛑 Problems

- Write any discovered & unresolved problems (link to created Jira issues)

## 💡 More ideas

Write any more ideas you have
