### PR TITLE
Replace old rfcx-ark bucket with ingest bucket

### DIFF
--- a/noncore/_utils/rfcx-mqtt/mqtt-checkin-router.js
+++ b/noncore/_utils/rfcx-mqtt/mqtt-checkin-router.js
@@ -1,11 +1,9 @@
-const Promise = require('bluebird')
 const cachedFiles = require('../internal-rfcx/cached-files').cachedFiles
 const mqttInputData = require('../rfcx-mqtt/mqtt-input-data').mqttInputData
 const checkInDatabase = require('../rfcx-mqtt/mqtt-database').checkInDatabase
 const checkInAssets = require('../rfcx-mqtt/mqtt-checkin-assets').checkInAssets
 const mqttInstructions = require('../rfcx-mqtt/mqtt-instructions').mqttInstructions
 const guardianCommand = require('../rfcx-guardian/guardian-command-publish').guardianCommand
-const mqttStreams = require('../rfcx-mqtt/mqtt-streams')
 const { expandAbbreviatedFieldNames } = require('./expand-abbreviated')
 
 function onMessageCheckin (data, messageId) {
@@ -58,12 +56,6 @@ function onMessageCheckin (data, messageId) {
     })
     .then((checkInObj) => {
       return checkInDatabase.createDbMetaVideo(checkInObj)
-    })
-    .then((checkInObj) => {
-      if (process.env.INGEST_SERVICE_ENABLED === 'true') {
-        return mqttStreams.ingestGuardianAudio(checkInObj)
-      }
-      return Promise.resolve(checkInObj)
     })
     .then((checkInObj) => {
       return checkInDatabase.finalizeCheckIn(checkInObj)

--- a/noncore/_utils/rfcx-mqtt/mqtt-input-data.js
+++ b/noncore/_utils/rfcx-mqtt/mqtt-input-data.js
@@ -6,9 +6,6 @@ const aws = require('../external/aws').aws()
 const assetUtils = require('../internal-rfcx/asset-utils').assetUtils
 const Promise = require('bluebird')
 const guardianMsgParsingUtils = require('../rfcx-guardian/guardian-msg-parsing-utils').guardianMsgParsingUtils
-const { upload } = require('../internal-rfcx/ingest-file-upload')
-const moment = require('moment-timezone')
-const path = require('path')
 
 exports.mqttInputData = {
 
@@ -49,7 +46,9 @@ exports.mqttInputData = {
           cacheFileBufferToFile(audioFileBuffer, true, checkInObj.audio.metaArr[3], checkInObj.audio.metaArr[2])
             .then(function (audioFileCacheFilePath) {
               checkInObj.audio.filePath = audioFileCacheFilePath
-              return saveAssetFileToS3('audio', checkInObj)
+              // Skip upload audio to rfcx-ark
+              // return saveAssetFileToS3('audio', checkInObj)
+              return checkInObj
             })
             .then(function (checkInObj) {
               checkInObj.screenshots.metaArr = (strArrToJSArr(checkInObj.json.screenshots, '|', '*').length === 0) ? [] : strArrToJSArr(checkInObj.json.screenshots, '|', '*')[0]
@@ -99,39 +98,31 @@ exports.mqttInputData = {
 
 }
 
-async function saveAssetFileToS3 (assetType, checkInObj) {
-  if (checkInObj[assetType].filePath == null) {
-    return checkInObj
-  } else {
-    let s3Path = assetUtils.getGuardianAssetStoragePath(assetType, new Date(parseInt(checkInObj[assetType].metaArr[1])), checkInObj.json.guardian.guid, checkInObj[assetType].metaArr[2])
-    let s3Bucket = process.env.ASSET_BUCKET_META
-    if (assetType === 'audio') {
-      const uploadData = await upload({
-        filename: path.basename(checkInObj.audio.meta.s3Path),
-        timestamp: moment.tz(checkInObj.audio.meta.measuredAt, 'UTC').toISOString(),
-        stream: checkInObj.db.dbGuardian.stream_id,
-        checksum: checkInObj.audio.meta.sha1CheckSum,
-        targetBitrate: checkInObj.audio.meta.bitRate,
-        sampleRate: checkInObj.audio.meta.sampleRate
-      })
-      s3Bucket = uploadData.bucket
-      s3Path = uploadData.path
-    }
-
-    aws.s3(s3Bucket).putFile(checkInObj[assetType].filePath, s3Path, function (s3SaveErr, s3Res) {
-      try { s3Res.resume() } catch (resumeErr) { console.error(resumeErr) }
-
-      if (s3SaveErr) {
-        console.error(s3SaveErr)
-        throw new Error(s3SaveErr)
-      } else if ((s3Res.statusCode === 200) && aws.s3ConfirmSave(s3Res, s3Path)) {
-        return checkInObj
+function saveAssetFileToS3 (assetType, checkInObj) {
+  return new Promise(function (resolve, reject) {
+    try {
+      if (checkInObj[assetType].filePath == null) {
+        resolve(checkInObj)
       } else {
-        console.error('S3 Save result', s3Res)
-        throw new Error('asset file (' + assetType + ') could not be saved to s3')
+        const s3Path = assetUtils.getGuardianAssetStoragePath(assetType, new Date(parseInt(checkInObj[assetType].metaArr[1])), checkInObj.json.guardian.guid, checkInObj[assetType].metaArr[2])
+        const s3Bucket = (assetType === 'audio') ? process.env.ASSET_BUCKET_AUDIO : process.env.ASSET_BUCKET_META
+
+        aws.s3(s3Bucket).putFile(checkInObj[assetType].filePath, s3Path, function (s3SaveErr, s3Res) {
+          try { s3Res.resume() } catch (resumeErr) { console.error(resumeErr) }
+
+          if (s3SaveErr) {
+            console.error(s3SaveErr)
+            reject(new Error(s3SaveErr))
+          } else if ((s3Res.statusCode === 200) && aws.s3ConfirmSave(s3Res, s3Path)) {
+            resolve(checkInObj)
+          } else {
+            console.error('S3 Save result', s3Res)
+            reject(new Error('asset file (' + assetType + ') could not be saved to s3'))
+          }
+        })
       }
-    })
-  }
+    } catch (errSaveAssetToS3) { console.error(errSaveAssetToS3); reject(new Error(errSaveAssetToS3)) }
+  })
 }
 
 function cacheFileBufferToFile (fileBuffer, isGZipped, fileSha1Hash, fileExtension) {

--- a/noncore/_utils/rfcx-mqtt/mqtt-streams.js
+++ b/noncore/_utils/rfcx-mqtt/mqtt-streams.js
@@ -18,7 +18,7 @@ async function ingestGuardianAudio (checkInObj) {
     targetBitrate: checkInObj.audio.meta.bitRate,
     sampleRate: checkInObj.audio.meta.sampleRate
   })
-  await S3Service.copyObject(process.env.ASSET_BUCKET_AUDIO, checkInObj.audio.meta.s3Path, uploadData.bucket, uploadData.path)
+  await S3Service.putObject(checkInObj.audio.filePath, uploadData.path, uploadData.bucket)
 
   return checkInObj
 }


### PR DESCRIPTION
## ✅ DoD

- [x] Resolves #634 

_(use na when API docs (Release notes, etc) do not need to be updated)_

## 📝 Summary
- Edit the code less possible
- Replace copy with put file
- Using bucket and path from `ingest-api` `POST /uploads` endpoint
