### PR TITLE
Don't remove source file if ingest service is enabled

### DIFF
--- a/noncore/_utils/rfcx-audio/audio-transcode.js
+++ b/noncore/_utils/rfcx-audio/audio-transcode.js
@@ -112,7 +112,8 @@ exports.audioUtils = {
                 reject(err)
               })
               .on('end', function () {
-                if (!inputParams.keepFile) {
+                // Don't remove source file if ingest service is enabled
+                if (process.env.INGEST_SERVICE_ENABLED !== 'true') {
                   fs.unlink(inputParams.sourceFilePath, function (e) { if (e) { console.error(e) } })
                 }
                 resolve(transcodedFilePath)

--- a/noncore/_utils/rfcx-mqtt/mqtt-checkin-assets.js
+++ b/noncore/_utils/rfcx-mqtt/mqtt-checkin-assets.js
@@ -39,6 +39,7 @@ exports.checkInAssets = {
                   if (err) { console.error(err); reject(err) }
 
                   checkInObj.audio.meta.captureSampleCount = parseInt(stdout.trim())
+                  assetUtils.deleteLocalFileFromFileSystem(wavFilePath)
                   resolve(checkInObj)
                 })
               })


### PR DESCRIPTION
- Revert back remove tranconded `.wav`
- If ingest service api is enabled, don't remove source file
