### PR TITLE
Add `palette` to media api option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.14 (2024-09-xx)
+### Features
+* **media**: Add `p` query param to `GET /internal/assets/streams/{filename}` endpoint for more colors
+
 ## 1.3.13 (2024-05-xx)
 ### Features
 * **core**: Add param `query_streams` `query_start` `query_end` `query_hours` to `GET /classifier-jobs` endpoint

--- a/core/internal/assets/streams.js
+++ b/core/internal/assets/streams.js
@@ -24,6 +24,8 @@ const { gluedDateStrToMoment } = require('../../_utils/datetime/parse')
     d  = dimension e.g. 200x512 (for file type spec only)
     w  = window function dolph by default (for file type spec only)
     z  = contrast of spectrogram (int) possible range is between 20 and 180 (for file type spec only)
+    m  = monochrome, to set spectrogram color to greyscale (true, false)
+    p  = palette, to set spectrogram color to the available ones (p1 - p4) need `m` to be `false`
 */
 
 /**
@@ -45,6 +47,8 @@ const { gluedDateStrToMoment } = require('../../_utils/datetime/parse')
  *                      `d`  = dimension e.g. 200x512 (for file type spec only) (e.g. `d600.512`)</br>
  *                      `w`  = window function dolph by default (for file type spec only) (e,g, `wdolph`)</br>
  *                      `z`  = contrast of spectrogram (int) possible range is between 20 and 180 (for file type spec only) (e.g. `z120`)</br>
+ *                      `m`  = monochrome, to set spectrogram color to greyscale (true, false)</br>
+ *                      `p`  = palette, to set spectrogram color to the available ones (p1 - p4) need `m` to be `false`</br>
  *                      Full examples:</br>
  *                      - Spectrogram format (fspec):</br>
  *                      `ij4yexu6o52d_t20191227T134400000Z.20191227T134420000Z_rfull_g1_fspec_d600.512_wdolph_z120.png`</br>

--- a/core/stream-segments/bl/segment-file-parsing.js
+++ b/core/stream-segments/bl/segment-file-parsing.js
@@ -51,6 +51,7 @@ function parseFileNameAttrs (name) {
         : undefined,
       windowFunc: findStartsWith('w') || 'dolph',
       monochrome: findStartsWith('m') || 'false',
+      palette: findStartsWith('p') || '1',
       zAxis: findStartsWith('z') || '120',
       jpegCompression: findStartsWith('c') || 0
       // sampleRate: findStartsWith('sr'),

--- a/core/stream-segments/bl/segment-file-utils.js
+++ b/core/stream-segments/bl/segment-file-utils.js
@@ -221,7 +221,7 @@ async function convertAudio (segments, starts, ends, attrs, outputPath, extensio
 
 async function makeSpectrogram (sourcePath, outputPath, filename, fileExtension, attrs) {
   const height = getSoxFriendlyHeight(attrs.dimensions.y)
-  await renderSpectrogram(sourcePath, outputPath, attrs.monochrome, attrs.dimensions.x, height, attrs.windowFunc, attrs.zAxis)
+  await renderSpectrogram(sourcePath, outputPath, attrs.monochrome, attrs.palette, attrs.dimensions.x, height, attrs.windowFunc, attrs.zAxis)
   if (attrs.clip && attrs.clip !== 'full') {
     await cropSpectrogram(outputPath, attrs, height)
   }
@@ -233,8 +233,25 @@ async function makeSpectrogram (sourcePath, outputPath, filename, fileExtension,
   return filename
 }
 
-function renderSpectrogram (sourcePath, outputPath, monochrome, width, height, windowFunc, zAxis) {
-  return runExec(`${SOX_PATH} ${sourcePath} -n spectrogram -r ${monochrome === 'true' ? '-lm' : '-h'} -o  ${outputPath} -x ${width} -y ${height} -w ${windowFunc} -z ${zAxis} -s`)
+function renderSpectrogram (sourcePath, outputPath, monochrome, palette, width, height, windowFunc, zAxis) {
+  let color = '-lm'
+  if (monochrome === 'true') {
+    color = '-lm'
+  } else {
+    switch (palette) {
+      case '1':
+        color = '-h'
+      case '2':
+        color = '-p6'
+      case '3':
+        color = '-p3'
+      case '4':
+        color = '-lr'
+      default:
+        color = '-h'
+    }
+  }
+  return runExec(`${SOX_PATH} ${sourcePath} -n spectrogram -r ${color} -o  ${outputPath} -x ${width} -y ${height} -w ${windowFunc} -z ${zAxis} -s`)
 }
 
 function hzToPx (height, sampleRate, hz) {

--- a/core/stream-segments/bl/segment-file-utils.js
+++ b/core/stream-segments/bl/segment-file-utils.js
@@ -241,12 +241,16 @@ function renderSpectrogram (sourcePath, outputPath, monochrome, palette, width, 
     switch (palette) {
       case '1':
         color = '-h'
+        break
       case '2':
         color = '-p6'
+        break
       case '3':
         color = '-p3'
+        break
       case '4':
         color = '-lr'
+        break
       default:
         color = '-h'
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rfcx-api",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "license": "UNLICENSED",
   "private": false,
   "repository": {


### PR DESCRIPTION
## ✅ DoD

- [x] API docs updated
- [x] Release notes updated

_(use na when API docs (Release notes, etc) do not need to be updated)_

## 📝 Summary

- Add `p` query param to `GET /internal/assets/streams/{filename}` endpoint for more colors

## 📸 Examples

- `ij4yexu6o52d_t20191227T134400000Z.20191227T134420000Z_rfull_g1_fspec_d600.512_mfalse_p1_wdolph_z120.png`
