### PR TITLE
feat(roles): add roleDisplayName to role serializers

### DIFF
--- a/core/roles/dao/index.js
+++ b/core/roles/dao/index.js
@@ -7,6 +7,21 @@ const MEMBER = 2
 const GUEST = 3
 const OWNER = 4
 
+// Display-only role label mapping. The internal role.name (e.g. 'Owner')
+// is preserved in API responses for backwards compatibility; this map is
+// added alongside as `roleDisplayName` for UIs that want a friendlier label.
+// Permission/auth logic must continue to use `role` (the internal name).
+const ROLE_DISPLAY_NAMES = {
+  Owner: 'Primary Admin',
+  Admin: 'Admin',
+  Member: 'Member',
+  Guest: 'Guest'
+}
+
+function getRoleDisplayName (roleName) {
+  return (roleName && ROLE_DISPLAY_NAMES[roleName]) || roleName
+}
+
 const ORGANIZATION = 'organization'
 const PROJECT = 'project'
 const STREAM = 'stream'
@@ -319,6 +334,7 @@ function getUsersForItem (id, itemName, filters) {
         return {
           ...item.user.toJSON(),
           role: item.role.name,
+          roleDisplayName: getRoleDisplayName(item.role.name),
           permissions: item.role.permissions.map(x => x.permission)
         }
       })
@@ -359,6 +375,7 @@ function getUserRoleForItem (id, userId, itemName, options = {}) {
       return {
         ...item.user.toJSON(),
         role: item.role.name,
+        roleDisplayName: getRoleDisplayName(item.role.name),
         permissions: item.role.permissions.map(x => x.permission)
       }
     })
@@ -425,6 +442,8 @@ module.exports = {
   getUserRoleForItem,
   addRole,
   removeRole,
+  getRoleDisplayName,
+  ROLE_DISPLAY_NAMES,
   ORGANIZATION,
   PROJECT,
   STREAM,

--- a/core/roles/dao/role-display-name.unit.test.js
+++ b/core/roles/dao/role-display-name.unit.test.js
@@ -1,0 +1,21 @@
+const { getRoleDisplayName, ROLE_DISPLAY_NAMES } = require('./index')
+
+describe('getRoleDisplayName', () => {
+  test('maps Owner to Primary Admin (display only)', () => {
+    expect(getRoleDisplayName('Owner')).toBe('Primary Admin')
+    expect(ROLE_DISPLAY_NAMES.Owner).toBe('Primary Admin')
+  })
+
+  test('keeps non-Owner role names unchanged', () => {
+    expect(getRoleDisplayName('Admin')).toBe('Admin')
+    expect(getRoleDisplayName('Member')).toBe('Member')
+    expect(getRoleDisplayName('Guest')).toBe('Guest')
+  })
+
+  test('falls back to the input when role is unknown / nullish', () => {
+    expect(getRoleDisplayName('Custom')).toBe('Custom')
+    expect(getRoleDisplayName(undefined)).toBe(undefined)
+    expect(getRoleDisplayName(null)).toBe(null)
+    expect(getRoleDisplayName('')).toBe('')
+  })
+})

--- a/core/roles/project.int.test.js
+++ b/core/roles/project.int.test.js
@@ -60,6 +60,7 @@ describe('GET /projects/:id/users', () => {
     expect(response.body[0].lastname).toBe('Bond')
     expect(response.body[0].email).toBe('jb@astonmartin.com')
     expect(response.body[0].role).toBe('Member')
+    expect(response.body[0].roleDisplayName).toBe('Member')
     expect(response.body[0].permissions.includes('C')).toBeTruthy()
     expect(response.body[0].permissions.includes('R')).toBeTruthy()
     expect(response.body[0].permissions.includes('U')).toBeTruthy()
@@ -78,6 +79,8 @@ describe('GET /projects/:id/users', () => {
     expect(response.body.length).toBe(1)
     const roles = response.body.map(u => u.role)
     expect(roles.includes('Owner')).toBeTruthy()
+    // Display-only label remap for Owner -> Primary Admin
+    expect(response.body[0].roleDisplayName).toBe('Primary Admin')
   })
 
   test('filter Owner and Admin', async () => {


### PR DESCRIPTION
## ✅ DoD

- [ ] API docs updated na
- [ ] Release notes updated na
- [ ] Deployment notes updated na
- [x] Unit or integration tests added
- [x] DB migrations tested na

_(use na when API docs (Release notes, etc) do not need to be updated)_

## 📝 Summary

- Adds `roleDisplayName` alongside the existing `role` field in role serializers.
- Maps `role: "Owner"` to `roleDisplayName: "Primary Admin"`.
- Preserves the existing API contract: `role: "Owner"` is unchanged.
- No DB, permission, or auth logic changes.

## 📸 Examples

```json
{
  "role": "Owner",
  "roleDisplayName": "Primary Admin",
  "permissions": ["C", "R", "U", "D"]
}
```

## 🛑 Problems

- Full local unit run has two unrelated suite load failures under `noncore/_utils/rfcx-guardian/...` from Node v25 + Twilio/jws crypto compatibility. The targeted role-display unit test passes.
- Integration tests were not run locally because they require the Docker/Postgres test stack.

### Tests run

- `node_modules/.bin/jest --forceExit --config ./test/jest.unit.config.js core/roles/dao/role-display-name`
- `node_modules/.bin/jest --forceExit --config ./test/jest.unit.config.js` (relevant tests pass; unrelated suite load issue noted above)
