### PR TITLE
noncore-mqtt: ingest Guardian audio via signed URL (not knox-s3)

### DIFF
--- a/noncore/_utils/rfcx-mqtt/mqtt-streams.js
+++ b/noncore/_utils/rfcx-mqtt/mqtt-streams.js
@@ -1,9 +1,16 @@
+const fs = require('fs')
+const rp = require('request-promise')
 const { upload } = require('../internal-rfcx/ingest-file-upload')
 const guardiansService = require('../../_services/guardians/guardians-service')
-const S3Service = require('../../_services/legacy/s3/s3-service')
 const moment = require('moment-timezone')
 const path = require('path')
 const assetUtils = require('../internal-rfcx/asset-utils').assetUtils
+
+const opusMimes = {
+  '.opus': 'audio/opus',
+  '.flac': 'audio/flac',
+  '.wav': 'audio/wav'
+}
 
 async function ingestGuardianAudio (checkInObj) {
   const guardian = await guardiansService.getGuardianByGuid(checkInObj.db.dbGuardian.guid)
@@ -20,7 +27,23 @@ async function ingestGuardianAudio (checkInObj) {
     sampleRate: checkInObj.audio.meta.sampleRate
   })
 
-  await S3Service.putObject(checkInObj.audio.filePath, uploadData.path, uploadData.bucket)
+  // Use the pre-signed URL returned by ingest-service rather than
+  // constructing our own AWS-direct S3 PUT via the legacy knox-s3
+  // client (S3Service.putObject). The signed URL points at whatever
+  // host ingest-service is configured to use:
+  //   - upstream / production: a *.s3.<region>.amazonaws.com URL.
+  //   - rfcx-local: an https://s3.arbimon.org URL that flows through
+  //     the edge to s3-writer + B2/R2.
+  // This makes the noncore-mqtt write surface follow the same edge
+  // routing as device direct-uploads, instead of bypassing it.
+  const ext = path.extname(checkInObj.audio.filePath).toLowerCase()
+  const contentType = opusMimes[ext] || 'audio/' + ext.slice(1)
+  await rp({
+    method: 'PUT',
+    url: uploadData.url,
+    body: fs.createReadStream(checkInObj.audio.filePath),
+    headers: { 'Content-Type': contentType }
+  })
   assetUtils.deleteLocalFileFromFileSystem(checkInObj.audio.filePath)
   return checkInObj
 }


### PR DESCRIPTION
## Summary

Guardian devices upload audio via MQTT to `noncore-mqtt`, which then needs to land the audio in S3. Today `noncore-mqtt` does:

```js
await S3Service.putObject(checkInObj.audio.filePath, uploadData.path, uploadData.bucket)
```

`S3Service.putObject` uses `noncore/_utils/external/aws.js` → `knox-s3`. `knox-s3` has **no endpoint option** — it always talks to AWS S3 directly, ignoring `AWS_S3_ENDPOINT`.

That means on **rfcx-local** the MQTT-driven write surface bypasses the edge entirely:
- Devices → MQTT → noncore-mqtt → **knox-s3 → AWS S3 direct** ❌
- Even though `ingest-service-api` returns a signed URL pointing at `https://s3.arbimon.org/...`, noncore-mqtt only uses `uploadData.path` + `uploadData.bucket` and rebuilds the URL via knox-s3 → AWS.

Identified empirically on rfcx-local 2026-05-18: every Guardian audio upload still landed at AWS `rfcx-ingest-production`, never at the local edge. Tracked extensively in `memory/2026-05-18.md`.

## Fix

PUT the file directly to `uploadData.url`. The URL is generated by `ingest-service /uploads` and already encodes the right host:

| Environment | `AWS_S3_ENDPOINT` | Signed URL host |
|---|---|---|
| Upstream / AWS-prod | unset | `*.s3.<region>.amazonaws.com` |
| rfcx-local | `https://s3.arbimon.org` | `s3.arbimon.org` (→ edge → s3-writer → B2/R2 + RabbitMQ publish) |

This is exactly the pattern the reference uploader (`rfcx/ingest-service/example/upload.js`) uses: `axios.put(uploadData.url, ...)`.

## Risk

Zero for AWS-prod (`AWS_S3_ENDPOINT` unset → signed URL points at AWS, same effective destination as before). For rfcx-local, the write now goes through `s3-writer` which fans out to B2 (writeThrough) and publishes a RabbitMQ event to `ingest-service-upload-production`, completing the local-only ingest loop wired up by `ingest-service` PR #88 + `rfcx-local` WS6.

## Side note: other knox-s3 call sites

This PR only fixes the hot path (Guardian MQTT audio). Other knox-s3 users in `noncore/_utils/` (audio-cache, checkin-audio, mqtt-input-data, guardian-meta-screenshots) still use the legacy path. The right long-term fix is to drop knox-s3 and route everything through `core/_services/storage/amazon.js` which already has the `AWS_S3_ENDPOINT` plumbing (commit `526630aa9`). Tracked as followup; not needed for ingest unblocking.

## Test plan

1. Merge to `staging` (AWS staging deploy is bit-identical no-op).
2. Promote `staging → master` to deploy.
3. On rfcx-local: watch s3-writer access logs for PUTs from MQTT-triggered uploads, plus RabbitMQ `ingest-service-upload-production` for published events.