### PR TITLE
Promote staging -> master (WS3 fix #650: signed-URL ingest path)

### DIFF
--- a/.github/workflows/reusable-build-lint-test.yaml
+++ b/.github/workflows/reusable-build-lint-test.yaml
@@ -52,9 +52,8 @@ jobs:
           --health-retries 5
 
     steps:
-      # v4 (4.1.1) @ Oct 2023 https://github.com/actions/checkout/tags
       - name: 'Setup: Git checkout'
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@v6
 
       - name: 'Setup: Node'
         # v4 (4.0.0) @ Oct 2023 https://github.com/actions/setup-node/tags
@@ -69,8 +68,7 @@ jobs:
           find test/init.d -type f | sort | PGPASSWORD=test xargs -n1 -I % psql -U postgres -h 127.0.0.1 -p 5433 -f %
 
       - name: 'Setup: Load npm dependencies cache'
-        # v3 (3.3.2) @ 8 Sep 2023 https://github.com/actions/cache/tags
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        uses: actions/cache@v5
         id: setup-dependency-cache
         with:
           path: '**/node_modules'

--- a/.github/workflows/reusable-build-lint-test.yaml
+++ b/.github/workflows/reusable-build-lint-test.yaml
@@ -83,8 +83,7 @@ jobs:
 
       - name: 'Setup: Load ESLint cache'
         if: ${{ inputs.lint }}
-        # v3 (3.0.1) @ 30 Mar 2022 https://github.com/actions/cache/tags
-        uses: actions/cache@136d96b4aee02b1f0de3ba493b1d47135042d9c0
+        uses: actions/cache@v5
         with:
           path: |
             .eslintcache

--- a/.github/workflows/reusable-k8s-deploy.yaml
+++ b/.github/workflows/reusable-k8s-deploy.yaml
@@ -23,8 +23,7 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     steps:
       - name: 'Setup: Git checkout'
-        # v3 (3.0.0) @ 02 Mar 2022 https://github.com/actions/checkout/tags
-        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+        uses: actions/checkout@v6
 
       - name: 'Deploy: Set image version'
         run: |

--- a/core/_services/arbimon/index.js
+++ b/core/_services/arbimon/index.js
@@ -11,7 +11,7 @@ const isEnabled = `${process.env.ARBIMON_ENABLED}` === 'true'
 function createProject (project, idToken) {
   const body = {};
   ['name', 'description'].forEach((attr) => { body[attr] = project[attr] })
-  body.is_private = !project.is_public
+  body.is_private = !project.isPublic
   body.external_id = project.id
   const options = {
     method: 'POST',

--- a/core/roles/dao/index.js
+++ b/core/roles/dao/index.js
@@ -7,6 +7,21 @@ const MEMBER = 2
 const GUEST = 3
 const OWNER = 4
 
+// Display-only role label mapping. The internal role.name (e.g. 'Owner')
+// is preserved in API responses for backwards compatibility; this map is
+// added alongside as `roleDisplayName` for UIs that want a friendlier label.
+// Permission/auth logic must continue to use `role` (the internal name).
+const ROLE_DISPLAY_NAMES = {
+  Owner: 'Primary Admin',
+  Admin: 'Admin',
+  Member: 'Member',
+  Guest: 'Guest'
+}
+
+function getRoleDisplayName (roleName) {
+  return (roleName && ROLE_DISPLAY_NAMES[roleName]) || roleName
+}
+
 const ORGANIZATION = 'organization'
 const PROJECT = 'project'
 const STREAM = 'stream'
@@ -319,6 +334,7 @@ function getUsersForItem (id, itemName, filters) {
         return {
           ...item.user.toJSON(),
           role: item.role.name,
+          roleDisplayName: getRoleDisplayName(item.role.name),
           permissions: item.role.permissions.map(x => x.permission)
         }
       })
@@ -359,6 +375,7 @@ function getUserRoleForItem (id, userId, itemName, options = {}) {
       return {
         ...item.user.toJSON(),
         role: item.role.name,
+        roleDisplayName: getRoleDisplayName(item.role.name),
         permissions: item.role.permissions.map(x => x.permission)
       }
     })
@@ -425,6 +442,8 @@ module.exports = {
   getUserRoleForItem,
   addRole,
   removeRole,
+  getRoleDisplayName,
+  ROLE_DISPLAY_NAMES,
   ORGANIZATION,
   PROJECT,
   STREAM,

--- a/core/roles/dao/role-display-name.unit.test.js
+++ b/core/roles/dao/role-display-name.unit.test.js
@@ -1,0 +1,21 @@
+const { getRoleDisplayName, ROLE_DISPLAY_NAMES } = require('./index')
+
+describe('getRoleDisplayName', () => {
+  test('maps Owner to Primary Admin (display only)', () => {
+    expect(getRoleDisplayName('Owner')).toBe('Primary Admin')
+    expect(ROLE_DISPLAY_NAMES.Owner).toBe('Primary Admin')
+  })
+
+  test('keeps non-Owner role names unchanged', () => {
+    expect(getRoleDisplayName('Admin')).toBe('Admin')
+    expect(getRoleDisplayName('Member')).toBe('Member')
+    expect(getRoleDisplayName('Guest')).toBe('Guest')
+  })
+
+  test('falls back to the input when role is unknown / nullish', () => {
+    expect(getRoleDisplayName('Custom')).toBe('Custom')
+    expect(getRoleDisplayName(undefined)).toBe(undefined)
+    expect(getRoleDisplayName(null)).toBe(null)
+    expect(getRoleDisplayName('')).toBe('')
+  })
+})

--- a/core/roles/project.int.test.js
+++ b/core/roles/project.int.test.js
@@ -60,6 +60,7 @@ describe('GET /projects/:id/users', () => {
     expect(response.body[0].lastname).toBe('Bond')
     expect(response.body[0].email).toBe('jb@astonmartin.com')
     expect(response.body[0].role).toBe('Member')
+    expect(response.body[0].roleDisplayName).toBe('Member')
     expect(response.body[0].permissions.includes('C')).toBeTruthy()
     expect(response.body[0].permissions.includes('R')).toBeTruthy()
     expect(response.body[0].permissions.includes('U')).toBeTruthy()
@@ -78,6 +79,8 @@ describe('GET /projects/:id/users', () => {
     expect(response.body.length).toBe(1)
     const roles = response.body.map(u => u.role)
     expect(roles.includes('Owner')).toBeTruthy()
+    // Display-only label remap for Owner -> Primary Admin
+    expect(response.body[0].roleDisplayName).toBe('Primary Admin')
   })
 
   test('filter Owner and Admin', async () => {

--- a/noncore/_utils/rfcx-mqtt/mqtt-streams.js
+++ b/noncore/_utils/rfcx-mqtt/mqtt-streams.js
@@ -1,9 +1,16 @@
+const fs = require('fs')
+const rp = require('request-promise')
 const { upload } = require('../internal-rfcx/ingest-file-upload')
 const guardiansService = require('../../_services/guardians/guardians-service')
-const S3Service = require('../../_services/legacy/s3/s3-service')
 const moment = require('moment-timezone')
 const path = require('path')
 const assetUtils = require('../internal-rfcx/asset-utils').assetUtils
+
+const opusMimes = {
+  '.opus': 'audio/opus',
+  '.flac': 'audio/flac',
+  '.wav': 'audio/wav'
+}
 
 async function ingestGuardianAudio (checkInObj) {
   const guardian = await guardiansService.getGuardianByGuid(checkInObj.db.dbGuardian.guid)
@@ -20,7 +27,23 @@ async function ingestGuardianAudio (checkInObj) {
     sampleRate: checkInObj.audio.meta.sampleRate
   })
 
-  await S3Service.putObject(checkInObj.audio.filePath, uploadData.path, uploadData.bucket)
+  // Use the pre-signed URL returned by ingest-service rather than
+  // constructing our own AWS-direct S3 PUT via the legacy knox-s3
+  // client (S3Service.putObject). The signed URL points at whatever
+  // host ingest-service is configured to use:
+  //   - upstream / production: a *.s3.<region>.amazonaws.com URL.
+  //   - rfcx-local: an https://s3.arbimon.org URL that flows through
+  //     the edge to s3-writer + B2/R2.
+  // This makes the noncore-mqtt write surface follow the same edge
+  // routing as device direct-uploads, instead of bypassing it.
+  const ext = path.extname(checkInObj.audio.filePath).toLowerCase()
+  const contentType = opusMimes[ext] || 'audio/' + ext.slice(1)
+  await rp({
+    method: 'PUT',
+    url: uploadData.url,
+    body: fs.createReadStream(checkInObj.audio.filePath),
+    headers: { 'Content-Type': contentType }
+  })
   assetUtils.deleteLocalFileFromFileSystem(checkInObj.audio.filePath)
   return checkInObj
 }


### PR DESCRIPTION
## Summary

Promotes `staging` to `master` to deploy the WS3 ingest pipeline fix (PR #650) plus pre-existing staging-only work to rfcx-local via the rfcx-local-cd job.

## Commits being promoted

| sha | author | subject |
|---|---|---|
| `758a72c5` | Topher White | noncore-mqtt: ingest Guardian audio via signed URL (not knox-s3) (#650) — **the critical fix** |
| `4d99e4e6` | (rfcx) | Merge pull request #649 from rfcx/feat/role-display-primary-admin |
| `a3c6ccf3` | (rfcx) | feat(roles): add roleDisplayName ('Owner' -> 'Primary Admin') in role serializers |
| `248d0bf3` | (rfcx) | Update more CI action |
| `38309a29` | (rfcx) | Update CI/CD actions |
| `84271ada` | (rfcx) | Fix isPublic bug |

The 5 non-Topher commits were already on `staging` before today, sitting there awaiting promotion — same pattern as `rfcx/ingest-service` PR #85.

## Why this is urgent

`ingest-service-tasks` on rfcx-local has been unable to process device uploads since the AWS SQS queue went dry (AWS-prod tasks consumed everything, but couldn't process because writer cutover moved upload records from Atlas to local Mongo).

This PR's `noncore-mqtt` fix routes new Guardian audio uploads through the rfcx-local edge → s3-writer → R2 + RabbitMQ publish → tasks consumer (WS3 + WS6 loop), ending the trigger-source mismatch.

## Deploy

`master` push triggers:
- AWS production deploy (treated as deprecated; outcome doesn't matter).
- **rfcx-local deploy** via `rfcx/cicd/.github/workflows/rfcx-local-cd.yaml@master` — pushes `core-api`, `core-tasks`, `noncore-api`, `noncore-mqtt` images to `192.168.5.1:30500` and rolls those four deployments.

## Verification after deploy

Tail s3-writer logs:
```
kubectl -n edge logs deploy/s3-writer | grep "published rmq"
```
Expect to see real device-pattern keys (`<streamId>/<uploadId>.opus`) being published, not just synthetic canaries.