### PR TITLE
core-api: POST /webhooks/bucket-events/object-created

### DIFF
--- a/common/middleware/body-parsing.js
+++ b/common/middleware/body-parsing.js
@@ -2,7 +2,14 @@ const bodyParser = require('body-parser')
 const multer = require('multer')
 
 const urlEncoded = bodyParser.urlencoded({ extended: false })
-const json = bodyParser.json({ limit: '5mb' })
+// `verify` stashes the raw request body on req.rawBody so downstream
+// middleware (e.g. HMAC-signature webhook auth in core/webhooks/bucket-events/) can
+// validate the bytes that were actually transmitted. Zero behavioural
+// impact on routes that don't read req.rawBody.
+const json = bodyParser.json({
+  limit: '5mb',
+  verify: (req, _res, buf) => { req.rawBody = buf }
+})
 const multipartFile = multer({ dest: process.env.CACHE_DIRECTORY + 'uploads/' })
 
 module.exports = { urlEncoded, json, multipartFile }

--- a/core/app.js
+++ b/core/app.js
@@ -33,6 +33,9 @@ for (const routeName in internalRoutes) {
   }
 }
 
+// Webhook routes (handle their own auth; no framework-level JWT wrapper)
+app.use('/webhooks', require('./webhooks'))
+
 // Support routes
 app.use(require('./info'))
 app.use('/docs', require('./_docs'))

--- a/core/webhooks/bucket-events/auth.js
+++ b/core/webhooks/bucket-events/auth.js
@@ -1,0 +1,76 @@
+/**
+ * Auth for bucket-event webhooks.
+ *
+ * Two acceptable modes per request, evaluated in order:
+ *
+ *   1. HMAC: header `X-Webhook-Signature: sha256=<hex>` carrying the
+ *      hex-encoded HMAC-SHA256 of the raw request body, keyed with
+ *      env EVENT_WEBHOOK_SECRET. Designed for Cloudflare R2 event
+ *      notifications and other external callers that don't have JWTs.
+ *
+ *   2. Bearer JWT: a system-user JWT validated by the standard passport
+ *      `jwt` strategy. Designed for internal callers (our own backfill
+ *      jobs, cron, etc.). Requires the `systemUser` role.
+ *
+ * If either passes, the request continues. If neither passes, 403.
+ *
+ * EVENT_WEBHOOK_SECRET is configured via the core-api Secret (NOT in
+ * the public ConfigMap). Without the env, only the JWT path is open.
+ */
+
+const crypto = require('crypto')
+const passport = require('passport')
+const { ForbiddenError } = require('../../../common/error-handling/errors')
+
+const HMAC_HEADER = 'x-webhook-signature'
+const HMAC_PREFIX = 'sha256='
+
+function timingSafeEqual (a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string' || a.length !== b.length) {
+    return false
+  }
+  try {
+    return crypto.timingSafeEqual(Buffer.from(a, 'utf8'), Buffer.from(b, 'utf8'))
+  } catch (e) {
+    return false
+  }
+}
+
+function computeHmac (secret, body) {
+  return HMAC_PREFIX + crypto.createHmac('sha256', secret).update(body).digest('hex')
+}
+
+/**
+ * Express middleware that gates webhook endpoints.
+ *
+ * Reads req.rawBody (populated by the global body-parser `verify`
+ * callback in common/middleware/body-parsing.js).
+ */
+function authenticateBucketEventWebhook (req, res, next) {
+  // Mode 1: HMAC.
+  const secret = process.env.EVENT_WEBHOOK_SECRET
+  const signature = req.headers[HMAC_HEADER]
+  if (secret && signature && req.rawBody) {
+    const expected = computeHmac(secret, req.rawBody)
+    if (timingSafeEqual(signature, expected)) {
+      req.webhookAuthMethod = 'hmac'
+      return next()
+    }
+  }
+
+  // Mode 2: Bearer JWT (systemUser).
+  passport.authenticate('jwt', { session: false }, (err, user) => {
+    if (err || !user) {
+      return next(new ForbiddenError('Invalid webhook signature and no valid bearer token'))
+    }
+    const roles = (user && (user.roles || user['https://rfcx.org/roles'])) || []
+    if (!Array.isArray(roles) || !roles.includes('systemUser')) {
+      return next(new ForbiddenError('Bearer token does not carry systemUser role'))
+    }
+    req.user = user
+    req.webhookAuthMethod = 'jwt'
+    return next()
+  })(req, res, next)
+}
+
+module.exports = { authenticateBucketEventWebhook, computeHmac }

--- a/core/webhooks/bucket-events/auth.unit.test.js
+++ b/core/webhooks/bucket-events/auth.unit.test.js
@@ -1,0 +1,24 @@
+const { computeHmac } = require('./auth')
+
+describe('bucket-events webhook auth: computeHmac', () => {
+  test('produces the expected sha256= prefixed hex for a known input', () => {
+    const secret = 'topsecret'
+    const body = Buffer.from('{"bucket":"rfcx-ingest-r2","key":"abc/def.opus"}')
+    const sig = computeHmac(secret, body)
+    expect(sig).toMatch(/^sha256=[0-9a-f]{64}$/)
+    // Verified independently:
+    //   echo -n '{"bucket":"rfcx-ingest-r2","key":"abc/def.opus"}' | \
+    //     openssl dgst -sha256 -hmac topsecret -hex
+    expect(sig).toBe('sha256=9ca63bd53084777bd0e991f530fd9e6ed1f5d47b82c06a220596d212008ae65a')
+  })
+
+  test('different bodies produce different signatures', () => {
+    const secret = 'k'
+    expect(computeHmac(secret, Buffer.from('a'))).not.toBe(computeHmac(secret, Buffer.from('b')))
+  })
+
+  test('different secrets produce different signatures', () => {
+    const body = Buffer.from('payload')
+    expect(computeHmac('s1', body)).not.toBe(computeHmac('s2', body))
+  })
+})

--- a/core/webhooks/bucket-events/index.js
+++ b/core/webhooks/bucket-events/index.js
@@ -1,0 +1,10 @@
+const express = require('express')
+const router = express.Router()
+const { authenticateBucketEventWebhook } = require('./auth')
+
+// Body is parsed by the global json middleware (common/middleware/body-parsing.js),
+// which also stashes the raw bytes on req.rawBody so the HMAC middleware
+// can verify Cloudflare's webhook signatures.
+router.post('/object-created', authenticateBucketEventWebhook, require('./object-created'))
+
+module.exports = router

--- a/core/webhooks/bucket-events/object-created.js
+++ b/core/webhooks/bucket-events/object-created.js
@@ -1,0 +1,77 @@
+/**
+ * POST /webhooks/bucket-events/object-created
+ *
+ * Notify the platform that an object was created in one of our managed
+ * buckets. Translates the call into an S3-event-shaped message on a
+ * RabbitMQ trigger queue (e.g. ingest-service-upload-production).
+ *
+ * Caller is either:
+ *   - Cloudflare R2 event notifications (HMAC-authenticated), or
+ *   - Internal services / cron / backfill (systemUser bearer JWT).
+ *
+ * Body:
+ *   {
+ *     "bucket": "rfcx-ingest-r2",                  // required
+ *     "key":    "<streamId>/<uploadId>.opus",      // required
+ *     "size":   168536                             // optional, bytes
+ *   }
+ *
+ * The bucket -> queue mapping is configured via env
+ * EVENT_QUEUE_BY_BUCKET, a JSON object e.g.:
+ *   { "rfcx-ingest-r2": "ingest-service-upload-production" }
+ * Buckets not in the map -> 400 Bad Request (defensive default).
+ *
+ * Idempotency: republishing the same key just re-triggers ingest,
+ * which dedupes by checksum in the existing ingest pipeline
+ * (ingest-service IngestionError DUPLICATE -> status=31).
+ */
+
+const { httpErrorHandler } = require('../../../common/error-handling/http')
+const Converter = require('../../../common/converter')
+const { ValidationError } = require('../../../common/error-handling/errors')
+const { publishObjectCreated } = require('./publisher')
+
+let _bucketQueueMap = null
+function getBucketQueueMap () {
+  if (_bucketQueueMap !== null) {
+    return _bucketQueueMap
+  }
+  const raw = process.env.EVENT_QUEUE_BY_BUCKET
+  if (!raw) {
+    _bucketQueueMap = {}
+    return _bucketQueueMap
+  }
+  try {
+    _bucketQueueMap = JSON.parse(raw)
+  } catch (e) {
+    console.error('EVENT_QUEUE_BY_BUCKET is set but is not valid JSON:', e.message)
+    _bucketQueueMap = {}
+  }
+  return _bucketQueueMap
+}
+
+module.exports = async function (req, res) {
+  const converter = new Converter(req.body, {})
+  converter.convert('bucket').toString()
+  converter.convert('key').toString()
+  converter.convert('size').optional().toInt().default(0)
+
+  try {
+    const params = await converter.validate()
+    const map = getBucketQueueMap()
+    const queueName = map[params.bucket]
+    if (!queueName) {
+      throw new ValidationError(`bucket ${params.bucket} is not configured as an event source (EVENT_QUEUE_BY_BUCKET)`)
+    }
+    await publishObjectCreated({
+      queueName,
+      bucket: params.bucket,
+      key: params.key,
+      size: params.size
+    })
+    console.info(`webhooks/bucket-events/object-created: published bucket=${params.bucket} key=${params.key} queue=${queueName} auth=${req.webhookAuthMethod || 'unknown'}`)
+    return res.status(204).end()
+  } catch (e) {
+    return httpErrorHandler(req, res, 'Failed to publish object-created event')(e)
+  }
+}

--- a/core/webhooks/bucket-events/publisher.js
+++ b/core/webhooks/bucket-events/publisher.js
@@ -1,0 +1,96 @@
+/**
+ * RabbitMQ publisher for bucket-event webhooks.
+ *
+ * Uses amqplib directly rather than @rfcx/message-queue because that
+ * library calls assertQueue() with empty arguments, which conflicts
+ * with the pre-declared quorum queue topology (x-queue-type=quorum +
+ * x-dead-letter-exchange) created via platform/rabbitmq/definitions.json.
+ *
+ * Connection state is lazy + recoverable: first publish opens a channel,
+ * subsequent publishes reuse it, and connection/channel errors drop the
+ * cached state so the next publish reconnects.
+ */
+
+const amqplib = require('amqplib')
+
+const URL = process.env.RABBITMQ_URL || process.env.AMQP_URL
+
+let _connection = null
+let _channel = null
+let _lock = Promise.resolve()
+
+async function _getChannel () {
+  if (_channel) {
+    return _channel
+  }
+  // Serialize connect attempts so concurrent first-callers don't open
+  // multiple connections.
+  _lock = _lock.then(async () => {
+    if (_channel) {
+      return _channel
+    }
+    if (!URL) {
+      throw new Error('RABBITMQ_URL (or AMQP_URL) env var must be set to publish events')
+    }
+    if (!_connection) {
+      _connection = await amqplib.connect(URL)
+      _connection.on('error', (err) => {
+        console.error('bucket-events publisher: rabbitmq connection error', err && err.message)
+      })
+      _connection.on('close', () => {
+        _connection = null
+        _channel = null
+      })
+    }
+    _channel = await _connection.createConfirmChannel()
+    _channel.on('error', (err) => {
+      console.error('bucket-events publisher: rabbitmq channel error', err && err.message)
+    })
+    _channel.on('close', () => { _channel = null })
+    return _channel
+  })
+  return _lock
+}
+
+/**
+ * Publish an ObjectCreated:Put event to a downstream consumer queue.
+ *
+ * Message body matches the existing AWS S3 event-notification shape
+ * that ingest-service-tasks already parses (Records[].s3.bucket/.object).
+ * The default exchange + routing-key=queueName routes directly to the
+ * queue without needing to declare an intermediate exchange.
+ */
+async function publishObjectCreated ({ queueName, bucket, key, size }) {
+  const channel = await _getChannel()
+  const body = JSON.stringify({
+    Records: [{
+      eventName: 'ObjectCreated:Put',
+      eventSource: 'rfcx-local:webhooks-bucket-events',
+      s3: {
+        bucket: {
+          name: bucket,
+          arn: `arn:aws:s3:::${bucket}`
+        },
+        object: {
+          key,
+          size: typeof size === 'number' ? size : 0
+        }
+      }
+    }]
+  })
+  // ConfirmChannel: callback resolves when the broker confirms persistent
+  // delivery to the queue, giving the caller real delivery semantics.
+  await new Promise((resolve, reject) => {
+    const ok = channel.sendToQueue(
+      queueName,
+      Buffer.from(body),
+      { persistent: true, contentType: 'application/json' },
+      (err) => { err ? reject(err) : resolve() }
+    )
+    if (!ok) {
+      channel.once('drain', () => {})
+    }
+  })
+}
+
+module.exports = { publishObjectCreated }

--- a/core/webhooks/index.js
+++ b/core/webhooks/index.js
@@ -1,0 +1,18 @@
+/**
+ * Top-level webhooks router.
+ *
+ * Webhooks bypass the framework's standard JWT-authenticate() wrapper
+ * because external callers (Cloudflare R2 event notifications, etc.)
+ * authenticate via HMAC signature, not bearer tokens. Each sub-route
+ * mounts its own auth middleware.
+ *
+ * Mounted in core/app.js at /webhooks, OUTSIDE the per-route-group
+ * authenticate() wrapper that core/internal routes get.
+ */
+
+const express = require('express')
+const router = express.Router()
+
+router.use('/bucket-events', require('./bucket-events'))
+
+module.exports = router

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@rapideditor/country-coder": "^5.2.2",
     "@rfcx/message-queue": "github:rfcx/message-queue#1.1.0",
     "@xmldom/xmldom": "0.8.10",
+    "amqplib": "^0.10.9",
     "archiver": "6.0.1",
     "ascii85": "1.0.2",
     "aws-sdk": "2.920.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2688,7 +2688,7 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==
 
-amqplib@^0.10.4:
+amqplib@^0.10.4, amqplib@^0.10.9:
   version "0.10.9"
   resolved "https://registry.yarnpkg.com/amqplib/-/amqplib-0.10.9.tgz#5b744c21d624f9307d0399e4d339b7354675831c"
   integrity sha512-jwSftI4QjS3mizvnSnOrPGYiUnm1vI2OP1iXeOUz5pb74Ua0nbf6nPyyTzuiCLEE3fMpaJORXh2K/TQ08H5xGA==


### PR DESCRIPTION
## Summary

Adds a generic bucket-event webhook endpoint that publishes S3-event-shaped messages to a RabbitMQ trigger queue.

```
POST https://api.rfcx.org/webhooks/bucket-events/object-created
Body: { "bucket": "rfcx-ingest-r2", "key": "<streamId>/<uploadId>.opus", "size": 168536 }
Auth: HMAC-SHA256 via X-Webhook-Signature header (env EVENT_WEBHOOK_SECRET),
      OR a systemUser-role bearer JWT
Response: 204 No Content (or 400/403)
```

## Why

Today's rfcx-local cutover is moving the entire ingest data plane off AWS. With the planned direct-to-R2 upload from clients (arbimon-uploader + noncore-mqtt → R2 via signed URL), there's no in-cluster intermediate that knows when a PUT completed. We need a generic notification surface that:

1. Cloudflare R2 event notifications can POST to (HMAC).
2. Our own internal services / cron / backfill can POST to (JWT).

This endpoint replaces the in-cluster `publishOnPut` hook that previously lived in `s3-writer` (the morning's WS6 work in `rfcx-local`). With clients uploading direct-to-R2, `s3-writer` no longer sits on the upload write path, so an in-process hook there can't catch device traffic.

The endpoint mirrors the existing AWS S3 event-record shape (`Records[].s3.bucket/.object`) so `ingest-service-tasks` consumes the same format whether the message came from AWS SQS (legacy) or this webhook (new).

## Implementation

| File | What |
|---|---|
| `core/webhooks/bucket-events/publisher.js` | amqplib client with lazy + recoverable connection state. ConfirmChannel + persistent delivery. |
| `core/webhooks/bucket-events/auth.js` | HMAC verification (constant-time compare) OR JWT-with-systemUser auth. |
| `core/webhooks/bucket-events/object-created.js` | The POST handler: validates body, resolves bucket→queue via env, publishes, returns 204. |
| `core/webhooks/bucket-events/auth.unit.test.js` | Unit tests for HMAC computation. 3 cases, all passing. |
| `core/webhooks/bucket-events/index.js` | Express sub-router. |
| `core/webhooks/index.js` | Express router that the top-level `app.use('/webhooks', ...)` mounts. |
| `core/app.js` | Mounts `/webhooks` outside the framework's per-route-group `authenticate()` wrapper (HMAC-only requests have no JWT). |
| `common/middleware/body-parsing.js` | json parser now stashes raw bytes on `req.rawBody` for HMAC verification. Zero impact on any other route. |
| `package.json` / `yarn.lock` | Adds `amqplib@^0.10.9` (used directly instead of `@rfcx/message-queue` which has the assertQueue/quorum-queue conflict — same pattern as `rfcx/ingest-service` PR #88). |

## Why direct amqplib instead of @rfcx/message-queue

The `@rfcx/message-queue` rabbitmq client calls `assertQueue(name, { durable: true })` on every publish. This fails with `PRECONDITION_FAILED` against the pre-declared queue topology used by rfcx-local (`x-queue-type=quorum + x-dead-letter-exchange=dlx`). Documented in `rfcx-local/memory/2026-05-18.md` and `rfcx/ingest-service` PR #88. Fix-upstream is tracked separately; using amqplib directly here is the same workaround.

## Config required at deploy time (NOT in this PR)

Three env vars, set via the rfcx-local repo's apps-prod manifests:

- `RABBITMQ_URL` — Secret. Reuses a scoped RabbitMQ user (publish-only access to the trigger queue + the amq.default exchange).
- `EVENT_WEBHOOK_SECRET` — Secret. Same value pasted into Cloudflare R2 event-notification config.
- `EVENT_QUEUE_BY_BUCKET` — ConfigMap. JSON mapping, e.g. `{"rfcx-ingest-r2":"ingest-service-upload-production"}`.

Without `RABBITMQ_URL`, the publisher throws a clear error on first call. Without `EVENT_QUEUE_BY_BUCKET`, every request returns 400. So the deployed code is safely dormant until configured.

## Risk

Zero for production (`AWS_S3_ENDPOINT` unset in AWS-prod, no R2 events fire, no internal callers wired up yet). The endpoint is dormant until config + Cloudflare wiring follow in `rfcx-local`.

For rfcx-local, the endpoint becomes the new trigger source once:
1. ingest-service is reconfigured to issue R2-direct signed URLs (separate PR).
2. Cloudflare R2 event notifications are configured to POST here with HMAC.
3. `s3-writer`'s `publishOnPut` hook is removed (separate PR in `rfcx-local`).

## Test plan post-deploy

```bash
# From inside cluster, via a systemUser JWT
curl -X POST https://api.rfcx.org/webhooks/bucket-events/object-created \
  -H "Authorization: Bearer $JWT" \
  -H "Content-Type: application/json" \
  -d '{"bucket":"rfcx-ingest-r2","key":"test/abc.opus","size":12345}'
# Expect: 204 + queue depth on ingest-service-upload-production = 1

# From outside, via HMAC
BODY='{"bucket":"rfcx-ingest-r2","key":"test/def.opus","size":12345}'
SIG=sha256=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "$EVENT_WEBHOOK_SECRET" -hex | cut -d' ' -f2)
curl -X POST https://api.rfcx.org/webhooks/bucket-events/object-created \
  -H "X-Webhook-Signature: $SIG" \
  -H "Content-Type: application/json" \
  -d "$BODY"
# Expect: 204

# Negative tests
# - Bad HMAC, no JWT -> 403
# - Unknown bucket -> 400
# - Missing body -> 400
```