### PR TITLE
feat(db): optional Sequelize PG read-replica routing with weighted read pool

### DIFF
--- a/common/db.js
+++ b/common/db.js
@@ -17,21 +17,43 @@ function getOptions (type) {
   // This matches the rfcx-local replica tier, where the replica
   // exposes the same credentials as the primary (it's a physical/
   // logical streaming replica, not a separate user surface).
+  //
+  // The read pool is weighted: the primary is listed
+  // POSTGRES_READ_PRIMARY_WEIGHT times alongside one replica entry.
+  // Sequelize round-robins across that pool, so weight=N gives an
+  // N:1 primary:replica read split. Default is 3 (75% primary,
+  // 25% replica), reflecting that the rfcx-local ms4 replica has
+  // roughly half the RAM of the ms5 primary (24 GiB vs 48 GiB) and
+  // a colder buffer pool; the primary's larger warm cache should
+  // continue serving most reads, with the replica acting as a
+  // release valve for extra capacity. Set the var to 0 to route
+  // all reads to the replica, or to a higher value to bias even
+  // further toward the primary.
   const replicaHost = !t ? process.env.POSTGRES_REPLICA_HOSTNAME : null
+  const primaryReadWeight = replicaHost
+    ? Math.max(0, parseInt(process.env.POSTGRES_READ_PRIMARY_WEIGHT || '3', 10))
+    : 0
+  const primaryConn = {
+    host: process.env.POSTGRES_HOSTNAME,
+    port: process.env.POSTGRES_PORT,
+    username: process.env.POSTGRES_USER,
+    password: process.env.POSTGRES_PASSWORD
+  }
+  const replicaConn = replicaHost
+    ? {
+        host: replicaHost,
+        port: process.env.POSTGRES_REPLICA_PORT || process.env.POSTGRES_PORT,
+        username: process.env.POSTGRES_REPLICA_USER || process.env.POSTGRES_USER,
+        password: process.env.POSTGRES_REPLICA_PASSWORD || process.env.POSTGRES_PASSWORD
+      }
+    : null
   const replicationConfig = replicaHost
     ? {
-        write: {
-          host: process.env.POSTGRES_HOSTNAME,
-          port: process.env.POSTGRES_PORT,
-          username: process.env.POSTGRES_USER,
-          password: process.env.POSTGRES_PASSWORD
-        },
-        read: [{
-          host: replicaHost,
-          port: process.env.POSTGRES_REPLICA_PORT || process.env.POSTGRES_PORT,
-          username: process.env.POSTGRES_REPLICA_USER || process.env.POSTGRES_USER,
-          password: process.env.POSTGRES_REPLICA_PASSWORD || process.env.POSTGRES_PASSWORD
-        }]
+        write: { ...primaryConn },
+        read: [
+          ...Array(primaryReadWeight).fill(primaryConn),
+          replicaConn
+        ]
       }
     : null
   const options = {

--- a/common/db.js
+++ b/common/db.js
@@ -2,6 +2,38 @@ const Sequelize = require('sequelize')
 
 function getOptions (type) {
   const t = process.env.NODE_ENV === 'test'
+  // Optional read-replica routing.
+  //
+  // When POSTGRES_REPLICA_HOSTNAME is set, Sequelize is configured
+  // with a `replication` block: SELECTs are auto-routed to the read
+  // pool, everything else (writes, transactions) goes to the write
+  // pool. When the env var is unset, behaviour is identical to the
+  // previous single-host configuration.
+  //
+  // Other replica connection params default to the primary's:
+  //   POSTGRES_REPLICA_PORT     -> POSTGRES_PORT
+  //   POSTGRES_REPLICA_USER     -> POSTGRES_USER
+  //   POSTGRES_REPLICA_PASSWORD -> POSTGRES_PASSWORD
+  // This matches the rfcx-local replica tier, where the replica
+  // exposes the same credentials as the primary (it's a physical/
+  // logical streaming replica, not a separate user surface).
+  const replicaHost = !t ? process.env.POSTGRES_REPLICA_HOSTNAME : null
+  const replicationConfig = replicaHost
+    ? {
+        write: {
+          host: process.env.POSTGRES_HOSTNAME,
+          port: process.env.POSTGRES_PORT,
+          username: process.env.POSTGRES_USER,
+          password: process.env.POSTGRES_PASSWORD
+        },
+        read: [{
+          host: replicaHost,
+          port: process.env.POSTGRES_REPLICA_PORT || process.env.POSTGRES_PORT,
+          username: process.env.POSTGRES_REPLICA_USER || process.env.POSTGRES_USER,
+          password: process.env.POSTGRES_REPLICA_PASSWORD || process.env.POSTGRES_PASSWORD
+        }]
+      }
+    : null
   const options = {
     dialect: 'postgres',
     dialectOptions: {
@@ -14,6 +46,7 @@ function getOptions (type) {
     database: !t ? (type === 'core' ? process.env.CORE_DB_NAME : process.env.NONCORE_DB_NAME) : 'postgres',
     username: !t ? process.env.POSTGRES_USER : 'postgres',
     password: !t ? process.env.POSTGRES_PASSWORD : 'test',
+    ...(replicationConfig ? { replication: replicationConfig } : {}),
     migrationStorageTableName: 'migrations',
     migrationStorageTableSchema: 'sequelize',
     logging: false,


### PR DESCRIPTION
## Summary

Adds optional Sequelize read-replica routing to the shared rfcx-api DB layer (`common/db.js`), behind a single new env var (`POSTGRES_REPLICA_HOSTNAME`). With it unset, behaviour is identical to today (no replication block, single host) — this PR is a no-op for every existing deploy.

The rfcx-local deployment has been running this code in production since 2026-05-18 (~14 hours and counting) on `media-api` as a canary; the change is small, env-gated, and already validated end-to-end. Landing it upstream so it survives the next CI rebuild.

## What changes

Two commits, both touching only `common/db.js`:

1. **`common/db.js: optional Sequelize replication mode for PG read-replica`**
   When `POSTGRES_REPLICA_HOSTNAME` is set, configures Sequelize with a `replication` block: SELECTs auto-route to the read pool, writes to the write pool. When unset, no replication block is configured (current behaviour, unchanged).

   Other replica connection params default to the primary's:
   - `POSTGRES_REPLICA_PORT` → `POSTGRES_PORT`
   - `POSTGRES_REPLICA_USER` → `POSTGRES_USER`
   - `POSTGRES_REPLICA_PASSWORD` → `POSTGRES_PASSWORD`

   (Matches the rfcx-local deployment, where the streaming replica shares credentials with the primary.)

2. **`common/db.js: weight primary in read pool (3:1 default)`**
   Adds `POSTGRES_READ_PRIMARY_WEIGHT` (default `3`). When set, builds Sequelize's `replication.read[]` array by listing the primary entry N times alongside one replica entry; Sequelize round-robins per read-connection-acquire, yielding an N:1 primary:replica split.

   Rationale: the rfcx-local ms4 replica has roughly half the primary's RAM (24 GiB vs 48 GiB) and a colder buffer pool. Routing 100% of reads to it would shift load from a warm cache to a cold one. The replica is intended as a release valve, not the default reader. Default `3` ≈ 75% primary / 25% replica.

## Behaviour matrix

| Setting | Effect |
|---|---|
| `POSTGRES_REPLICA_HOSTNAME` unset | No replication block; single host (== current behaviour) |
| `POSTGRES_REPLICA_HOSTNAME` set, `POSTGRES_READ_PRIMARY_WEIGHT=0` | 100% reads to replica |
| `POSTGRES_READ_PRIMARY_WEIGHT=1` | 50/50 split |
| `POSTGRES_READ_PRIMARY_WEIGHT=3` (default) | 75% primary / 25% replica |
| `POSTGRES_READ_PRIMARY_WEIGHT=9` | 90 / 10 |

## Sequelize 5 replication semantics (worth knowing before extending to other services)

When `replication: { write, read: [...] }` is set:
- **Writes** (`INSERT`, `UPDATE`, `DELETE`, `CREATE TABLE`, etc.) → write pool.
- **Transactions** (`sequelize.transaction(...)`) → all queries inside, including reads, use the write pool.
- **`Model.findX`** and `query(... { type: SELECT })` → read pool.
- **`sequelize.query(sql)` without `type`** → defaults to read pool. **Gotcha:** raw-SQL writes without an explicit `type: QueryTypes.INSERT/UPDATE/...` will silently target the read pool, which on a streaming replica is read-only and will fail with `cannot execute INSERT in a read-only transaction`. `media-api` is read-mostly so this hasn't surfaced; flagged here for the broader rollout.

## Validation (rfcx-local production canary)

- Built as `192.168.5.1:30500/core-api:rfcx-local-replica-canary-{1,2}` and rolled to `apps-prod/media-api` since 2026-05-18 ~11:50 EDT.
- Replica replay lag stayed at single-digit ms throughout.
- 247 commits / 891k tup_returned on `postgres-replica db=core` within ~7 min of rollout; 0 errors observed.
- 25% read split (canary-2) verified via per-host connection counts under burst.

## No-op confirmation

Existing deployments that don't set `POSTGRES_REPLICA_HOSTNAME` get the same Sequelize options object as before (the `replication` key is only added inside the `if (replicaHost)` branch). No schema, dependency, or API surface changes.

## Follow-ups (not this PR)

- Replica-down failover behaviour audit (Sequelize's default is to retry the read pool; we should validate fallback to write pool on read pool exhaustion).
- Read-after-write protection for any time-sensitive endpoints (replay lag is ~5ms but non-zero).
- Once landed, drop the local `rfcx-local-replica-canary-*` image tags and let the CI-built image carry this.
