### PR TITLE
Promote staging -> master (AWS CD-strip + feat PRs)

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -35,29 +35,6 @@ jobs:
             echo "::set-output name=namespace::testing"
           fi
 
-  build:
-    name: 'Build'
-    needs: [prepare, configure]
-    uses: rfcx/cicd/.github/workflows/ecr-build-push.yaml@master
-    with:
-      dockerfile: build/Dockerfile
-      targets: "[\"core-api\",\"core-tasks\",\"noncore-api\",\"noncore-mqtt\"]"
-      tag-environment: ${{ needs.configure.outputs.namespace }}
-      tag-latest: ${{ needs.configure.outputs.namespace == 'production' }}
-    secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-  deploy:
-    name: 'Deploy'
-    needs: [build, configure]
-    uses: ./.github/workflows/reusable-k8s-deploy.yaml
-    with:
-      tag: ${{ needs.build.outputs.unique-tag }}
-      namespace: ${{ needs.configure.outputs.namespace }}
-    secrets:
-      kube-config: ${{ secrets.KUBE_CONFIG_SUPER }}
-
   deploy-rfcx-local:
     name: 'Deploy: rfcx-local'
     needs: [prepare, configure]
@@ -80,17 +57,17 @@ jobs:
   notify:
     name: 'Notify'
     if: ${{ always() }}
-    needs: [prepare, build, deploy, deploy-rfcx-local]
+    needs: [prepare, deploy-rfcx-local]
     uses: rfcx/cicd/.github/workflows/notify-send.yaml@master
     with:
       repo: rfcx-api
       branch-name: ${{ needs.prepare.outputs.branch-name }}
       workflow-id: cd.yaml
       previous-run-id: ${{ needs.prepare.outputs.previous-run-id }}
-      status: ${{ needs.deploy.result }}
+      status: ${{ needs.deploy-rfcx-local.result }}
       always: true
       notification-title: 'CD: APIs'
-      notification-footer: "Build: ${{ needs.build.result || 'n/a' }} | Deploy: ${{ needs.deploy.result || 'n/a' }}"
+      notification-footer: "Deploy (rfcx-local): ${{ needs.deploy-rfcx-local.result || 'n/a' }}"
       notification-success-statement: '{0} deployed the build!'
     secrets:
       slack-webhook: ${{ secrets.SLACK_ALERT_COREDT_WEBHOOK }}

--- a/common/db.js
+++ b/common/db.js
@@ -17,21 +17,43 @@ function getOptions (type) {
   // This matches the rfcx-local replica tier, where the replica
   // exposes the same credentials as the primary (it's a physical/
   // logical streaming replica, not a separate user surface).
+  //
+  // The read pool is weighted: the primary is listed
+  // POSTGRES_READ_PRIMARY_WEIGHT times alongside one replica entry.
+  // Sequelize round-robins across that pool, so weight=N gives an
+  // N:1 primary:replica read split. Default is 3 (75% primary,
+  // 25% replica), reflecting that the rfcx-local ms4 replica has
+  // roughly half the RAM of the ms5 primary (24 GiB vs 48 GiB) and
+  // a colder buffer pool; the primary's larger warm cache should
+  // continue serving most reads, with the replica acting as a
+  // release valve for extra capacity. Set the var to 0 to route
+  // all reads to the replica, or to a higher value to bias even
+  // further toward the primary.
   const replicaHost = !t ? process.env.POSTGRES_REPLICA_HOSTNAME : null
+  const primaryReadWeight = replicaHost
+    ? Math.max(0, parseInt(process.env.POSTGRES_READ_PRIMARY_WEIGHT || '3', 10))
+    : 0
+  const primaryConn = {
+    host: process.env.POSTGRES_HOSTNAME,
+    port: process.env.POSTGRES_PORT,
+    username: process.env.POSTGRES_USER,
+    password: process.env.POSTGRES_PASSWORD
+  }
+  const replicaConn = replicaHost
+    ? {
+        host: replicaHost,
+        port: process.env.POSTGRES_REPLICA_PORT || process.env.POSTGRES_PORT,
+        username: process.env.POSTGRES_REPLICA_USER || process.env.POSTGRES_USER,
+        password: process.env.POSTGRES_REPLICA_PASSWORD || process.env.POSTGRES_PASSWORD
+      }
+    : null
   const replicationConfig = replicaHost
     ? {
-        write: {
-          host: process.env.POSTGRES_HOSTNAME,
-          port: process.env.POSTGRES_PORT,
-          username: process.env.POSTGRES_USER,
-          password: process.env.POSTGRES_PASSWORD
-        },
-        read: [{
-          host: replicaHost,
-          port: process.env.POSTGRES_REPLICA_PORT || process.env.POSTGRES_PORT,
-          username: process.env.POSTGRES_REPLICA_USER || process.env.POSTGRES_USER,
-          password: process.env.POSTGRES_REPLICA_PASSWORD || process.env.POSTGRES_PASSWORD
-        }]
+        write: { ...primaryConn },
+        read: [
+          ...Array(primaryReadWeight).fill(primaryConn),
+          replicaConn
+        ]
       }
     : null
   const options = {

--- a/common/db.js
+++ b/common/db.js
@@ -2,6 +2,38 @@ const Sequelize = require('sequelize')
 
 function getOptions (type) {
   const t = process.env.NODE_ENV === 'test'
+  // Optional read-replica routing.
+  //
+  // When POSTGRES_REPLICA_HOSTNAME is set, Sequelize is configured
+  // with a `replication` block: SELECTs are auto-routed to the read
+  // pool, everything else (writes, transactions) goes to the write
+  // pool. When the env var is unset, behaviour is identical to the
+  // previous single-host configuration.
+  //
+  // Other replica connection params default to the primary's:
+  //   POSTGRES_REPLICA_PORT     -> POSTGRES_PORT
+  //   POSTGRES_REPLICA_USER     -> POSTGRES_USER
+  //   POSTGRES_REPLICA_PASSWORD -> POSTGRES_PASSWORD
+  // This matches the rfcx-local replica tier, where the replica
+  // exposes the same credentials as the primary (it's a physical/
+  // logical streaming replica, not a separate user surface).
+  const replicaHost = !t ? process.env.POSTGRES_REPLICA_HOSTNAME : null
+  const replicationConfig = replicaHost
+    ? {
+        write: {
+          host: process.env.POSTGRES_HOSTNAME,
+          port: process.env.POSTGRES_PORT,
+          username: process.env.POSTGRES_USER,
+          password: process.env.POSTGRES_PASSWORD
+        },
+        read: [{
+          host: replicaHost,
+          port: process.env.POSTGRES_REPLICA_PORT || process.env.POSTGRES_PORT,
+          username: process.env.POSTGRES_REPLICA_USER || process.env.POSTGRES_USER,
+          password: process.env.POSTGRES_REPLICA_PASSWORD || process.env.POSTGRES_PASSWORD
+        }]
+      }
+    : null
   const options = {
     dialect: 'postgres',
     dialectOptions: {
@@ -14,6 +46,7 @@ function getOptions (type) {
     database: !t ? (type === 'core' ? process.env.CORE_DB_NAME : process.env.NONCORE_DB_NAME) : 'postgres',
     username: !t ? process.env.POSTGRES_USER : 'postgres',
     password: !t ? process.env.POSTGRES_PASSWORD : 'test',
+    ...(replicationConfig ? { replication: replicationConfig } : {}),
     migrationStorageTableName: 'migrations',
     migrationStorageTableSchema: 'sequelize',
     logging: false,


### PR DESCRIPTION
## Summary

Promotes `staging` → `master` (production). Carries the AWS CD-strip + any feature PRs that landed on staging in this cycle.

## Contents

Per `gh api compare master...staging` at PR-open time — see commit list on this PR for the authoritative set. Expected high-level changes:

1. **AWS `build:`/`deploy:` jobs removed from `cd.yaml`** (kops decommissioned per operator decision 2026-05-18 18:55 EDT). `deploy-rfcx-local:` is the sole CD path going forward. Workflow now: `prepare → configure → deploy-rfcx-local → notify`.

2. **For `rfcx-api`**: also carries [#654](https://github.com/rfcx/rfcx-api/pull/654) — optional Sequelize PG read-replica routing with weighted read pool (env-gated via `POSTGRES_REPLICA_HOSTNAME`; no-op when unset).

3. **For `ingest-service`**: also carries [#92](https://github.com/rfcx/ingest-service/pull/92) — `res.headersSent` early-return + structured `uncaughtException`/`unhandledRejection` handlers.

## What happens on merge

CD triggers immediately on push to `master`:
- `prepare → configure → deploy-rfcx-local (namespace=production)` 
- The runner builds each target stage with `docker buildx --platform linux/arm64`, pushes to `192.168.5.1:30500/<image>:rfcx-local-prod-<short-sha>`
- `kubectl set image` rolls each apps-prod Deployment named in the workflow's `deployments:` list
- `kubectl rollout status --timeout=180s` per deployment

## Rollback

Standard chain: revert this PR (creates a counter-promotion), then push it through. Or revert the originating commits on `master` and roll the previous image tag back via `kubectl -n apps-prod set image deploy/<name> <container>=192.168.5.1:30500/<image>:<prev-rfcx-local-prod-sha>`.

## Related

- Companion `staging → master` PRs across the rfcx-org sweep.
- `evity-squibbon/rfcx-local` STATE.md "AWS / kops decommission status" block.