### PR TITLE
Reconcile develop with master (post-tier promotion + CD strip)

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -62,7 +62,7 @@ jobs:
     name: 'Deploy: rfcx-local'
     needs: [prepare, configure]
     if: ${{ needs.configure.outputs.namespace == 'production' }}
-    uses: evity-squibbon/rfcx-local/.github/workflows/rfcx-local-cd.yaml@main
+    uses: rfcx/cicd/.github/workflows/rfcx-local-cd.yaml@master
     with:
       repo: rfcx-api
       dockerfile: build/Dockerfile

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -35,29 +35,6 @@ jobs:
             echo "::set-output name=namespace::testing"
           fi
 
-  build:
-    name: 'Build'
-    needs: [prepare, configure]
-    uses: rfcx/cicd/.github/workflows/ecr-build-push.yaml@master
-    with:
-      dockerfile: build/Dockerfile
-      targets: "[\"core-api\",\"core-tasks\",\"noncore-api\",\"noncore-mqtt\"]"
-      tag-environment: ${{ needs.configure.outputs.namespace }}
-      tag-latest: ${{ needs.configure.outputs.namespace == 'production' }}
-    secrets:
-      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-  deploy:
-    name: 'Deploy'
-    needs: [build, configure]
-    uses: ./.github/workflows/reusable-k8s-deploy.yaml
-    with:
-      tag: ${{ needs.build.outputs.unique-tag }}
-      namespace: ${{ needs.configure.outputs.namespace }}
-    secrets:
-      kube-config: ${{ secrets.KUBE_CONFIG_SUPER }}
-
   deploy-rfcx-local:
     name: 'Deploy: rfcx-local'
     needs: [prepare, configure]
@@ -80,17 +57,17 @@ jobs:
   notify:
     name: 'Notify'
     if: ${{ always() }}
-    needs: [prepare, build, deploy, deploy-rfcx-local]
+    needs: [prepare, deploy-rfcx-local]
     uses: rfcx/cicd/.github/workflows/notify-send.yaml@master
     with:
       repo: rfcx-api
       branch-name: ${{ needs.prepare.outputs.branch-name }}
       workflow-id: cd.yaml
       previous-run-id: ${{ needs.prepare.outputs.previous-run-id }}
-      status: ${{ needs.deploy.result }}
+      status: ${{ needs.deploy-rfcx-local.result }}
       always: true
       notification-title: 'CD: APIs'
-      notification-footer: "Build: ${{ needs.build.result || 'n/a' }} | Deploy: ${{ needs.deploy.result || 'n/a' }}"
+      notification-footer: "Deploy (rfcx-local): ${{ needs.deploy-rfcx-local.result || 'n/a' }}"
       notification-success-statement: '{0} deployed the build!'
     secrets:
       slack-webhook: ${{ secrets.SLACK_ALERT_COREDT_WEBHOOK }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -58,10 +58,29 @@ jobs:
     secrets:
       kube-config: ${{ secrets.KUBE_CONFIG_SUPER }}
 
+  deploy-rfcx-local:
+    name: 'Deploy: rfcx-local'
+    needs: [prepare, configure]
+    if: ${{ needs.configure.outputs.namespace == 'production' }}
+    uses: evity-squibbon/rfcx-local/.github/workflows/rfcx-local-cd.yaml@main
+    with:
+      repo: rfcx-api
+      dockerfile: build/Dockerfile
+      targets: '["core-api","core-tasks","noncore-api","noncore-mqtt"]'
+      deployments: |
+        [
+          {"name": "core-api",     "image": "core-api"},
+          {"name": "core-tasks",   "image": "core-tasks"},
+          {"name": "noncore-api",  "image": "noncore-api"},
+          {"name": "noncore-mqtt", "image": "noncore-mqtt"},
+          {"name": "media-api",    "image": "core-api"}
+        ]
+
+
   notify:
     name: 'Notify'
     if: ${{ always() }}
-    needs: [prepare, build, deploy]
+    needs: [prepare, build, deploy, deploy-rfcx-local]
     uses: rfcx/cicd/.github/workflows/notify-send.yaml@master
     with:
       repo: rfcx-api

--- a/common/db.js
+++ b/common/db.js
@@ -17,21 +17,43 @@ function getOptions (type) {
   // This matches the rfcx-local replica tier, where the replica
   // exposes the same credentials as the primary (it's a physical/
   // logical streaming replica, not a separate user surface).
+  //
+  // The read pool is weighted: the primary is listed
+  // POSTGRES_READ_PRIMARY_WEIGHT times alongside one replica entry.
+  // Sequelize round-robins across that pool, so weight=N gives an
+  // N:1 primary:replica read split. Default is 3 (75% primary,
+  // 25% replica), reflecting that the rfcx-local ms4 replica has
+  // roughly half the RAM of the ms5 primary (24 GiB vs 48 GiB) and
+  // a colder buffer pool; the primary's larger warm cache should
+  // continue serving most reads, with the replica acting as a
+  // release valve for extra capacity. Set the var to 0 to route
+  // all reads to the replica, or to a higher value to bias even
+  // further toward the primary.
   const replicaHost = !t ? process.env.POSTGRES_REPLICA_HOSTNAME : null
+  const primaryReadWeight = replicaHost
+    ? Math.max(0, parseInt(process.env.POSTGRES_READ_PRIMARY_WEIGHT || '3', 10))
+    : 0
+  const primaryConn = {
+    host: process.env.POSTGRES_HOSTNAME,
+    port: process.env.POSTGRES_PORT,
+    username: process.env.POSTGRES_USER,
+    password: process.env.POSTGRES_PASSWORD
+  }
+  const replicaConn = replicaHost
+    ? {
+        host: replicaHost,
+        port: process.env.POSTGRES_REPLICA_PORT || process.env.POSTGRES_PORT,
+        username: process.env.POSTGRES_REPLICA_USER || process.env.POSTGRES_USER,
+        password: process.env.POSTGRES_REPLICA_PASSWORD || process.env.POSTGRES_PASSWORD
+      }
+    : null
   const replicationConfig = replicaHost
     ? {
-        write: {
-          host: process.env.POSTGRES_HOSTNAME,
-          port: process.env.POSTGRES_PORT,
-          username: process.env.POSTGRES_USER,
-          password: process.env.POSTGRES_PASSWORD
-        },
-        read: [{
-          host: replicaHost,
-          port: process.env.POSTGRES_REPLICA_PORT || process.env.POSTGRES_PORT,
-          username: process.env.POSTGRES_REPLICA_USER || process.env.POSTGRES_USER,
-          password: process.env.POSTGRES_REPLICA_PASSWORD || process.env.POSTGRES_PASSWORD
-        }]
+        write: { ...primaryConn },
+        read: [
+          ...Array(primaryReadWeight).fill(primaryConn),
+          replicaConn
+        ]
       }
     : null
   const options = {

--- a/common/db.js
+++ b/common/db.js
@@ -2,6 +2,38 @@ const Sequelize = require('sequelize')
 
 function getOptions (type) {
   const t = process.env.NODE_ENV === 'test'
+  // Optional read-replica routing.
+  //
+  // When POSTGRES_REPLICA_HOSTNAME is set, Sequelize is configured
+  // with a `replication` block: SELECTs are auto-routed to the read
+  // pool, everything else (writes, transactions) goes to the write
+  // pool. When the env var is unset, behaviour is identical to the
+  // previous single-host configuration.
+  //
+  // Other replica connection params default to the primary's:
+  //   POSTGRES_REPLICA_PORT     -> POSTGRES_PORT
+  //   POSTGRES_REPLICA_USER     -> POSTGRES_USER
+  //   POSTGRES_REPLICA_PASSWORD -> POSTGRES_PASSWORD
+  // This matches the rfcx-local replica tier, where the replica
+  // exposes the same credentials as the primary (it's a physical/
+  // logical streaming replica, not a separate user surface).
+  const replicaHost = !t ? process.env.POSTGRES_REPLICA_HOSTNAME : null
+  const replicationConfig = replicaHost
+    ? {
+        write: {
+          host: process.env.POSTGRES_HOSTNAME,
+          port: process.env.POSTGRES_PORT,
+          username: process.env.POSTGRES_USER,
+          password: process.env.POSTGRES_PASSWORD
+        },
+        read: [{
+          host: replicaHost,
+          port: process.env.POSTGRES_REPLICA_PORT || process.env.POSTGRES_PORT,
+          username: process.env.POSTGRES_REPLICA_USER || process.env.POSTGRES_USER,
+          password: process.env.POSTGRES_REPLICA_PASSWORD || process.env.POSTGRES_PASSWORD
+        }]
+      }
+    : null
   const options = {
     dialect: 'postgres',
     dialectOptions: {
@@ -14,6 +46,7 @@ function getOptions (type) {
     database: !t ? (type === 'core' ? process.env.CORE_DB_NAME : process.env.NONCORE_DB_NAME) : 'postgres',
     username: !t ? process.env.POSTGRES_USER : 'postgres',
     password: !t ? process.env.POSTGRES_PASSWORD : 'test',
+    ...(replicationConfig ? { replication: replicationConfig } : {}),
     migrationStorageTableName: 'migrations',
     migrationStorageTableSchema: 'sequelize',
     logging: false,

--- a/common/message-queue/sns.js
+++ b/common/message-queue/sns.js
@@ -1,7 +1,12 @@
 const isEnabled = process.env.MESSAGE_QUEUE_ENABLED === 'true'
 
 /**
- * Get the SNS MessageQueue from the environment configuration
+ * Get the SNS MessageQueue from the environment configuration.
+ *
+ * Mirrors sqs.js: backend is selectable via MESSAGE_QUEUE_KIND for the
+ * fan-out publisher. Default 'sns' matches production behavior; setting
+ * to 'rabbitmq' uses the same in-cluster broker as sqs.js does.
+ *
  * @module snsMessageQueue
  * @type {MessageQueue}
  */
@@ -9,7 +14,8 @@ let messageQueue
 
 if (isEnabled) {
   const { MessageQueue } = require('@rfcx/message-queue')
-  messageQueue = new MessageQueue('sns', {
+  const kind = process.env.MESSAGE_QUEUE_KIND_SNS || (process.env.MESSAGE_QUEUE_KIND === 'rabbitmq' ? 'rabbitmq' : 'sns')
+  messageQueue = new MessageQueue(kind, {
     endpoint: process.env.MESSAGE_QUEUE_ENDPOINT,
     topicPrefix: process.env.MESSAGE_QUEUE_PREFIX
   })

--- a/common/message-queue/sqs.js
+++ b/common/message-queue/sqs.js
@@ -1,7 +1,19 @@
 const isEnabled = process.env.MESSAGE_QUEUE_ENABLED === 'true'
 
 /**
- * Get the SQS MessageQueue from the environment configuration
+ * Get the default MessageQueue from the environment configuration.
+ *
+ * The module is still named `sqs` for backwards-compatibility (it's the
+ * publisher for `segmentCreated`, `classifierJobFinished` etc. that
+ * core-tasks listens to). The backend is now selectable via the env var
+ * MESSAGE_QUEUE_KIND:
+ *
+ *   MESSAGE_QUEUE_KIND=sqs       (default) — AWS SQS, production behavior
+ *   MESSAGE_QUEUE_KIND=rabbitmq  — AMQP broker via RABBITMQ_URL
+ *
+ * When MESSAGE_QUEUE_ENABLED!=true, returns a no-op stub (unchanged
+ * upstream behavior — must opt into the queue explicitly).
+ *
  * @module sqsMessageQueue
  * @type {MessageQueue}
  */
@@ -9,7 +21,8 @@ let messageQueue
 
 if (isEnabled) {
   const { MessageQueue } = require('@rfcx/message-queue')
-  messageQueue = new MessageQueue('sqs', {
+  const kind = process.env.MESSAGE_QUEUE_KIND || 'sqs'
+  messageQueue = new MessageQueue(kind, {
     endpoint: process.env.MESSAGE_QUEUE_ENDPOINT,
     topicPrefix: process.env.MESSAGE_QUEUE_PREFIX
   })

--- a/common/middleware/body-parsing.js
+++ b/common/middleware/body-parsing.js
@@ -2,7 +2,14 @@ const bodyParser = require('body-parser')
 const multer = require('multer')
 
 const urlEncoded = bodyParser.urlencoded({ extended: false })
-const json = bodyParser.json({ limit: '5mb' })
+// `verify` stashes the raw request body on req.rawBody so downstream
+// middleware (e.g. HMAC-signature webhook auth in core/webhooks/bucket-events/) can
+// validate the bytes that were actually transmitted. Zero behavioural
+// impact on routes that don't read req.rawBody.
+const json = bodyParser.json({
+  limit: '5mb',
+  verify: (req, _res, buf) => { req.rawBody = buf }
+})
 const multipartFile = multer({ dest: process.env.CACHE_DIRECTORY + 'uploads/' })
 
 module.exports = { urlEncoded, json, multipartFile }

--- a/core/_services/storage/amazon.js
+++ b/core/_services/storage/amazon.js
@@ -1,11 +1,20 @@
 const fs = require('fs')
 const S3 = require('aws-sdk/clients/s3')
 
-const s3Client = new S3({
+// rfcx-local fork: support MinIO (or any S3-compatible endpoint) when
+// AWS_S3_ENDPOINT is set. Production with empty AWS_S3_ENDPOINT remains
+// bit-identical to upstream behavior.
+const _s3Config = {
   accessKeyId: process.env.AWS_ACCESS_KEY_ID,
   secretAccessKey: process.env.AWS_SECRET_KEY,
   region: process.env.AWS_REGION_ID
-})
+}
+if (process.env.AWS_S3_ENDPOINT) {
+  _s3Config.endpoint = process.env.AWS_S3_ENDPOINT
+  _s3Config.s3ForcePathStyle = process.env.AWS_S3_FORCE_PATH_STYLE === 'true'
+  _s3Config.signatureVersion = 'v4'
+}
+const s3Client = new S3(_s3Config)
 
 function getSignedUrl (bucket, key, contentType, expires = 86400, write = false) {
   const params = {

--- a/core/app.js
+++ b/core/app.js
@@ -33,6 +33,9 @@ for (const routeName in internalRoutes) {
   }
 }
 
+// Webhook routes (handle their own auth; no framework-level JWT wrapper)
+app.use('/webhooks', require('./webhooks'))
+
 // Support routes
 app.use(require('./info'))
 app.use('/docs', require('./_docs'))

--- a/core/webhooks/bucket-events/auth.js
+++ b/core/webhooks/bucket-events/auth.js
@@ -1,0 +1,76 @@
+/**
+ * Auth for bucket-event webhooks.
+ *
+ * Two acceptable modes per request, evaluated in order:
+ *
+ *   1. HMAC: header `X-Webhook-Signature: sha256=<hex>` carrying the
+ *      hex-encoded HMAC-SHA256 of the raw request body, keyed with
+ *      env EVENT_WEBHOOK_SECRET. Designed for Cloudflare R2 event
+ *      notifications and other external callers that don't have JWTs.
+ *
+ *   2. Bearer JWT: a system-user JWT validated by the standard passport
+ *      `jwt` strategy. Designed for internal callers (our own backfill
+ *      jobs, cron, etc.). Requires the `systemUser` role.
+ *
+ * If either passes, the request continues. If neither passes, 403.
+ *
+ * EVENT_WEBHOOK_SECRET is configured via the core-api Secret (NOT in
+ * the public ConfigMap). Without the env, only the JWT path is open.
+ */
+
+const crypto = require('crypto')
+const passport = require('passport')
+const { ForbiddenError } = require('../../../common/error-handling/errors')
+
+const HMAC_HEADER = 'x-webhook-signature'
+const HMAC_PREFIX = 'sha256='
+
+function timingSafeEqual (a, b) {
+  if (typeof a !== 'string' || typeof b !== 'string' || a.length !== b.length) {
+    return false
+  }
+  try {
+    return crypto.timingSafeEqual(Buffer.from(a, 'utf8'), Buffer.from(b, 'utf8'))
+  } catch (e) {
+    return false
+  }
+}
+
+function computeHmac (secret, body) {
+  return HMAC_PREFIX + crypto.createHmac('sha256', secret).update(body).digest('hex')
+}
+
+/**
+ * Express middleware that gates webhook endpoints.
+ *
+ * Reads req.rawBody (populated by the global body-parser `verify`
+ * callback in common/middleware/body-parsing.js).
+ */
+function authenticateBucketEventWebhook (req, res, next) {
+  // Mode 1: HMAC.
+  const secret = process.env.EVENT_WEBHOOK_SECRET
+  const signature = req.headers[HMAC_HEADER]
+  if (secret && signature && req.rawBody) {
+    const expected = computeHmac(secret, req.rawBody)
+    if (timingSafeEqual(signature, expected)) {
+      req.webhookAuthMethod = 'hmac'
+      return next()
+    }
+  }
+
+  // Mode 2: Bearer JWT (systemUser).
+  passport.authenticate('jwt', { session: false }, (err, user) => {
+    if (err || !user) {
+      return next(new ForbiddenError('Invalid webhook signature and no valid bearer token'))
+    }
+    const roles = (user && (user.roles || user['https://rfcx.org/roles'])) || []
+    if (!Array.isArray(roles) || !roles.includes('systemUser')) {
+      return next(new ForbiddenError('Bearer token does not carry systemUser role'))
+    }
+    req.user = user
+    req.webhookAuthMethod = 'jwt'
+    return next()
+  })(req, res, next)
+}
+
+module.exports = { authenticateBucketEventWebhook, computeHmac }

--- a/core/webhooks/bucket-events/auth.unit.test.js
+++ b/core/webhooks/bucket-events/auth.unit.test.js
@@ -1,0 +1,24 @@
+const { computeHmac } = require('./auth')
+
+describe('bucket-events webhook auth: computeHmac', () => {
+  test('produces the expected sha256= prefixed hex for a known input', () => {
+    const secret = 'topsecret'
+    const body = Buffer.from('{"bucket":"rfcx-ingest-r2","key":"abc/def.opus"}')
+    const sig = computeHmac(secret, body)
+    expect(sig).toMatch(/^sha256=[0-9a-f]{64}$/)
+    // Verified independently:
+    //   echo -n '{"bucket":"rfcx-ingest-r2","key":"abc/def.opus"}' | \
+    //     openssl dgst -sha256 -hmac topsecret -hex
+    expect(sig).toBe('sha256=9ca63bd53084777bd0e991f530fd9e6ed1f5d47b82c06a220596d212008ae65a')
+  })
+
+  test('different bodies produce different signatures', () => {
+    const secret = 'k'
+    expect(computeHmac(secret, Buffer.from('a'))).not.toBe(computeHmac(secret, Buffer.from('b')))
+  })
+
+  test('different secrets produce different signatures', () => {
+    const body = Buffer.from('payload')
+    expect(computeHmac('s1', body)).not.toBe(computeHmac('s2', body))
+  })
+})

--- a/core/webhooks/bucket-events/index.js
+++ b/core/webhooks/bucket-events/index.js
@@ -1,0 +1,10 @@
+const express = require('express')
+const router = express.Router()
+const { authenticateBucketEventWebhook } = require('./auth')
+
+// Body is parsed by the global json middleware (common/middleware/body-parsing.js),
+// which also stashes the raw bytes on req.rawBody so the HMAC middleware
+// can verify Cloudflare's webhook signatures.
+router.post('/object-created', authenticateBucketEventWebhook, require('./object-created'))
+
+module.exports = router

--- a/core/webhooks/bucket-events/object-created.js
+++ b/core/webhooks/bucket-events/object-created.js
@@ -1,0 +1,77 @@
+/**
+ * POST /webhooks/bucket-events/object-created
+ *
+ * Notify the platform that an object was created in one of our managed
+ * buckets. Translates the call into an S3-event-shaped message on a
+ * RabbitMQ trigger queue (e.g. ingest-service-upload-production).
+ *
+ * Caller is either:
+ *   - Cloudflare R2 event notifications (HMAC-authenticated), or
+ *   - Internal services / cron / backfill (systemUser bearer JWT).
+ *
+ * Body:
+ *   {
+ *     "bucket": "rfcx-ingest-r2",                  // required
+ *     "key":    "<streamId>/<uploadId>.opus",      // required
+ *     "size":   168536                             // optional, bytes
+ *   }
+ *
+ * The bucket -> queue mapping is configured via env
+ * EVENT_QUEUE_BY_BUCKET, a JSON object e.g.:
+ *   { "rfcx-ingest-r2": "ingest-service-upload-production" }
+ * Buckets not in the map -> 400 Bad Request (defensive default).
+ *
+ * Idempotency: republishing the same key just re-triggers ingest,
+ * which dedupes by checksum in the existing ingest pipeline
+ * (ingest-service IngestionError DUPLICATE -> status=31).
+ */
+
+const { httpErrorHandler } = require('../../../common/error-handling/http')
+const Converter = require('../../../common/converter')
+const { ValidationError } = require('../../../common/error-handling/errors')
+const { publishObjectCreated } = require('./publisher')
+
+let _bucketQueueMap = null
+function getBucketQueueMap () {
+  if (_bucketQueueMap !== null) {
+    return _bucketQueueMap
+  }
+  const raw = process.env.EVENT_QUEUE_BY_BUCKET
+  if (!raw) {
+    _bucketQueueMap = {}
+    return _bucketQueueMap
+  }
+  try {
+    _bucketQueueMap = JSON.parse(raw)
+  } catch (e) {
+    console.error('EVENT_QUEUE_BY_BUCKET is set but is not valid JSON:', e.message)
+    _bucketQueueMap = {}
+  }
+  return _bucketQueueMap
+}
+
+module.exports = async function (req, res) {
+  const converter = new Converter(req.body, {})
+  converter.convert('bucket').toString()
+  converter.convert('key').toString()
+  converter.convert('size').optional().toInt().default(0)
+
+  try {
+    const params = await converter.validate()
+    const map = getBucketQueueMap()
+    const queueName = map[params.bucket]
+    if (!queueName) {
+      throw new ValidationError(`bucket ${params.bucket} is not configured as an event source (EVENT_QUEUE_BY_BUCKET)`)
+    }
+    await publishObjectCreated({
+      queueName,
+      bucket: params.bucket,
+      key: params.key,
+      size: params.size
+    })
+    console.info(`webhooks/bucket-events/object-created: published bucket=${params.bucket} key=${params.key} queue=${queueName} auth=${req.webhookAuthMethod || 'unknown'}`)
+    return res.status(204).end()
+  } catch (e) {
+    return httpErrorHandler(req, res, 'Failed to publish object-created event')(e)
+  }
+}

--- a/core/webhooks/bucket-events/publisher.js
+++ b/core/webhooks/bucket-events/publisher.js
@@ -1,0 +1,96 @@
+/**
+ * RabbitMQ publisher for bucket-event webhooks.
+ *
+ * Uses amqplib directly rather than @rfcx/message-queue because that
+ * library calls assertQueue() with empty arguments, which conflicts
+ * with the pre-declared quorum queue topology (x-queue-type=quorum +
+ * x-dead-letter-exchange) created via platform/rabbitmq/definitions.json.
+ *
+ * Connection state is lazy + recoverable: first publish opens a channel,
+ * subsequent publishes reuse it, and connection/channel errors drop the
+ * cached state so the next publish reconnects.
+ */
+
+const amqplib = require('amqplib')
+
+const URL = process.env.RABBITMQ_URL || process.env.AMQP_URL
+
+let _connection = null
+let _channel = null
+let _lock = Promise.resolve()
+
+async function _getChannel () {
+  if (_channel) {
+    return _channel
+  }
+  // Serialize connect attempts so concurrent first-callers don't open
+  // multiple connections.
+  _lock = _lock.then(async () => {
+    if (_channel) {
+      return _channel
+    }
+    if (!URL) {
+      throw new Error('RABBITMQ_URL (or AMQP_URL) env var must be set to publish events')
+    }
+    if (!_connection) {
+      _connection = await amqplib.connect(URL)
+      _connection.on('error', (err) => {
+        console.error('bucket-events publisher: rabbitmq connection error', err && err.message)
+      })
+      _connection.on('close', () => {
+        _connection = null
+        _channel = null
+      })
+    }
+    _channel = await _connection.createConfirmChannel()
+    _channel.on('error', (err) => {
+      console.error('bucket-events publisher: rabbitmq channel error', err && err.message)
+    })
+    _channel.on('close', () => { _channel = null })
+    return _channel
+  })
+  return _lock
+}
+
+/**
+ * Publish an ObjectCreated:Put event to a downstream consumer queue.
+ *
+ * Message body matches the existing AWS S3 event-notification shape
+ * that ingest-service-tasks already parses (Records[].s3.bucket/.object).
+ * The default exchange + routing-key=queueName routes directly to the
+ * queue without needing to declare an intermediate exchange.
+ */
+async function publishObjectCreated ({ queueName, bucket, key, size }) {
+  const channel = await _getChannel()
+  const body = JSON.stringify({
+    Records: [{
+      eventName: 'ObjectCreated:Put',
+      eventSource: 'rfcx-local:webhooks-bucket-events',
+      s3: {
+        bucket: {
+          name: bucket,
+          arn: `arn:aws:s3:::${bucket}`
+        },
+        object: {
+          key,
+          size: typeof size === 'number' ? size : 0
+        }
+      }
+    }]
+  })
+  // ConfirmChannel: callback resolves when the broker confirms persistent
+  // delivery to the queue, giving the caller real delivery semantics.
+  await new Promise((resolve, reject) => {
+    const ok = channel.sendToQueue(
+      queueName,
+      Buffer.from(body),
+      { persistent: true, contentType: 'application/json' },
+      (err) => { err ? reject(err) : resolve() }
+    )
+    if (!ok) {
+      channel.once('drain', () => {})
+    }
+  })
+}
+
+module.exports = { publishObjectCreated }

--- a/core/webhooks/index.js
+++ b/core/webhooks/index.js
@@ -1,0 +1,18 @@
+/**
+ * Top-level webhooks router.
+ *
+ * Webhooks bypass the framework's standard JWT-authenticate() wrapper
+ * because external callers (Cloudflare R2 event notifications, etc.)
+ * authenticate via HMAC signature, not bearer tokens. Each sub-route
+ * mounts its own auth middleware.
+ *
+ * Mounted in core/app.js at /webhooks, OUTSIDE the per-route-group
+ * authenticate() wrapper that core/internal routes get.
+ */
+
+const express = require('express')
+const router = express.Router()
+
+router.use('/bucket-events', require('./bucket-events'))
+
+module.exports = router

--- a/noncore/_utils/rfcx-mqtt/mqtt-streams.js
+++ b/noncore/_utils/rfcx-mqtt/mqtt-streams.js
@@ -1,9 +1,16 @@
+const fs = require('fs')
+const rp = require('request-promise')
 const { upload } = require('../internal-rfcx/ingest-file-upload')
 const guardiansService = require('../../_services/guardians/guardians-service')
-const S3Service = require('../../_services/legacy/s3/s3-service')
 const moment = require('moment-timezone')
 const path = require('path')
 const assetUtils = require('../internal-rfcx/asset-utils').assetUtils
+
+const opusMimes = {
+  '.opus': 'audio/opus',
+  '.flac': 'audio/flac',
+  '.wav': 'audio/wav'
+}
 
 async function ingestGuardianAudio (checkInObj) {
   const guardian = await guardiansService.getGuardianByGuid(checkInObj.db.dbGuardian.guid)
@@ -20,7 +27,23 @@ async function ingestGuardianAudio (checkInObj) {
     sampleRate: checkInObj.audio.meta.sampleRate
   })
 
-  await S3Service.putObject(checkInObj.audio.filePath, uploadData.path, uploadData.bucket)
+  // Use the pre-signed URL returned by ingest-service rather than
+  // constructing our own AWS-direct S3 PUT via the legacy knox-s3
+  // client (S3Service.putObject). The signed URL points at whatever
+  // host ingest-service is configured to use:
+  //   - upstream / production: a *.s3.<region>.amazonaws.com URL.
+  //   - rfcx-local: an https://s3.arbimon.org URL that flows through
+  //     the edge to s3-writer + B2/R2.
+  // This makes the noncore-mqtt write surface follow the same edge
+  // routing as device direct-uploads, instead of bypassing it.
+  const ext = path.extname(checkInObj.audio.filePath).toLowerCase()
+  const contentType = opusMimes[ext] || 'audio/' + ext.slice(1)
+  await rp({
+    method: 'PUT',
+    url: uploadData.url,
+    body: fs.createReadStream(checkInObj.audio.filePath),
+    headers: { 'Content-Type': contentType }
+  })
   assetUtils.deleteLocalFileFromFileSystem(checkInObj.audio.filePath)
   return checkInObj
 }

--- a/noncore/v1/guardians/guardians.js
+++ b/noncore/v1/guardians/guardians.js
@@ -11,8 +11,8 @@ router.route('/')
       res.json([])
     } else {
       const siteIds = [ // ids copies from deleted UserSiteRelations table
-        1, 3, 6, 8, 13, 23, 26, 28, 30, 31, 32, 35, 38, 39, 40, 41, 43, 44,
-        45, 47, 48, 49, 50, 51, 53, 54, 55, 56, 57, 60, 62, 63, 64, 65]
+        3, 6, 8, 13, 23, 26, 28, 30, 31, 32, 35, 38, 39, 40, 41, 43, 44,
+        45, 47, 48, 49, 50, 51, 53, 54, 55, 56, 57, 60, 62, 63, 64, 65, 69]
       models.Guardian.findAll({
         attributes: ['guid', 'is_visible', 'last_check_in', 'shortname', 'latitude', 'longitude'],
         include: [{

--- a/noncore/v1/guardians/guardians.js
+++ b/noncore/v1/guardians/guardians.js
@@ -11,7 +11,7 @@ router.route('/')
       res.json([])
     } else {
       const siteIds = [ // ids copies from deleted UserSiteRelations table
-        3, 6, 8, 13, 23, 26, 28, 30, 31, 32, 35, 38, 39, 40, 41, 43, 44,
+        1, 3, 6, 8, 13, 23, 26, 28, 30, 31, 32, 35, 38, 39, 40, 41, 43, 44,
         45, 47, 48, 49, 50, 51, 53, 54, 55, 56, 57, 60, 62, 63, 64, 65]
       models.Guardian.findAll({
         attributes: ['guid', 'is_visible', 'last_check_in', 'shortname', 'latitude', 'longitude'],

--- a/noncore/v1/guardians/guardians.js
+++ b/noncore/v1/guardians/guardians.js
@@ -12,7 +12,7 @@ router.route('/')
     } else {
       const siteIds = [ // ids copies from deleted UserSiteRelations table
         3, 6, 8, 13, 23, 26, 28, 30, 31, 32, 35, 38, 39, 40, 41, 43, 44,
-        45, 47, 48, 49, 50, 51, 53, 54, 55, 56, 57, 60, 62, 63, 64, 65, 69]
+        45, 47, 48, 49, 50, 51, 53, 54, 55, 56, 57, 60, 62, 63, 64, 65, 69, 70]
       models.Guardian.findAll({
         attributes: ['guid', 'is_visible', 'last_check_in', 'shortname', 'latitude', 'longitude'],
         include: [{

--- a/noncore/views/v1/models/guardian-audio.js
+++ b/noncore/views/v1/models/guardian-audio.js
@@ -36,7 +36,9 @@ exports.models = {
     const queryParams = parsePermittedQueryParams(req.query, clipDurationFull)
 
     // auto-generate the asset filepath if it's not stored in the url column
+    console.info(`stream_id: ${dbRow.Guardian.stream_id}, star: ${dbRow.measured_at}`)
     const segment = await StreamSegment.findOne({ where: { stream_id: dbRow.Guardian.stream_id, start: dbRow.measured_at } })
+    console.info(`result: ${segment}`)
     if (!segment) {
       return res.status(404).json({ msg: 'Recording not found' })
     }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@google-cloud/storage": "7.7.0",
     "@googlemaps/google-maps-services-js": "^3.3.42",
     "@rapideditor/country-coder": "^5.2.2",
-    "@rfcx/message-queue": "^1.0.8",
+    "@rfcx/message-queue": "github:rfcx/message-queue#1.1.0",
     "@xmldom/xmldom": "0.8.10",
     "archiver": "6.0.1",
     "ascii85": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@rapideditor/country-coder": "^5.2.2",
     "@rfcx/message-queue": "github:rfcx/message-queue#1.1.0",
     "@xmldom/xmldom": "0.8.10",
+    "amqplib": "^0.10.9",
     "archiver": "6.0.1",
     "ascii85": "1.0.2",
     "aws-sdk": "2.920.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1746,11 +1746,11 @@
   dependencies:
     which-polygon "^2.2.1"
 
-"@rfcx/message-queue@^1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@rfcx/message-queue/-/message-queue-1.0.8.tgz#50d2305725aaa4141496fb5e67a92386fda8f856"
-  integrity sha512-LtnkS4Lsh0ozs2zbfZGjLjxR4+HbApKlsj2d/Zbm6GbcB2nWea9L0lAUJ8TIbxbelZEnMGdj6jxGShGYGmhnqw==
+"@rfcx/message-queue@github:rfcx/message-queue#1.1.0":
+  version "1.1.0"
+  resolved "https://codeload.github.com/rfcx/message-queue/tar.gz/9e94964bc761ae4ca144fbb5da73bb3812bbbe06"
   dependencies:
+    amqplib "^0.10.4"
     aws-sdk "^2.988.0"
     sqs-consumer "^5.6.0"
 
@@ -2688,6 +2688,14 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==
 
+amqplib@^0.10.4:
+  version "0.10.9"
+  resolved "https://registry.yarnpkg.com/amqplib/-/amqplib-0.10.9.tgz#5b744c21d624f9307d0399e4d339b7354675831c"
+  integrity sha512-jwSftI4QjS3mizvnSnOrPGYiUnm1vI2OP1iXeOUz5pb74Ua0nbf6nPyyTzuiCLEE3fMpaJORXh2K/TQ08H5xGA==
+  dependencies:
+    buffer-more-ints "~1.0.0"
+    url-parse "~1.5.10"
+
 ansi-escapes@^4.2.1:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
@@ -3303,6 +3311,11 @@ buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
+buffer-more-ints@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz#ef4f8e2dddbad429ed3828a9c55d44f05c611422"
+  integrity sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==
 
 buffer-writer@2.0.0:
   version "2.0.0"
@@ -9679,7 +9692,7 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-url-parse@^1.5.9:
+url-parse@^1.5.9, url-parse@~1.5.10:
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
   integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2688,7 +2688,7 @@ amdefine@>=0.0.4:
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
   integrity sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==
 
-amqplib@^0.10.4:
+amqplib@^0.10.4, amqplib@^0.10.9:
   version "0.10.9"
   resolved "https://registry.yarnpkg.com/amqplib/-/amqplib-0.10.9.tgz#5b744c21d624f9307d0399e4d339b7354675831c"
   integrity sha512-jwSftI4QjS3mizvnSnOrPGYiUnm1vI2OP1iXeOUz5pb74Ua0nbf6nPyyTzuiCLEE3fMpaJORXh2K/TQ08H5xGA==


### PR DESCRIPTION
## Summary

Reconciles `develop` with the recent `master` state. The two branches have drifted apart for ~weeks because recent PRs went `feat → staging → master` (or `feat → master` directly) and never backflowed into `develop`. Tonight's CD-strip + tier-system + feat work compounded the drift.

## Why this PR exists

The cd.yaml in this repo says the deploy chain is `develop → staging → master`, but the actual chain in practice has been `feat → staging → master`. As a result, `develop` is silently behind and any future merge from `develop` would either revert production state or hit conflict-resolution overhead.

A `master → develop` reconciliation merge brings the branches back in line without losing anyone's in-flight feature work (no force-push, no rebase). After this lands, anyone branching off `develop` for new work starts from current production state.

## What changes

Merges `master` into `develop`. Result: `develop`'s history includes all `master` commits, plus a merge commit.

If there are local `develop`-only commits (PRs not yet merged to master), they're preserved by the merge. After this lands, `develop` may need a CI build to validate the union compiles cleanly.

## Risks

- **Low**: this is a routine reconciliation. The only common failure mode is if `develop` has work-in-progress commits that conflict with master's recent changes. Conflicts resolved per the usual convention (preserve newer behaviour from master where features overlap, preserve develop's WIP otherwise).
- **No behavior change in production**: master is already what's deployed. This PR doesn't deploy anything.

## After this lands

Recommend establishing a convention: open a `master → develop` reconciliation PR after every `staging → master` promotion, OR change `cd.yaml` to drop `develop` from the documented chain. Choosing one keeps the branches honest.