### PR TITLE
noncore audio: route legacy knox-s3 client through AWS_S3_ENDPOINT (rfcx-local)

### DIFF
--- a/noncore/_utils/external/aws.js
+++ b/noncore/_utils/external/aws.js
@@ -21,13 +21,34 @@ function getBucket (bucketName) {
 
 const s3Clients = {}
 
+// rfcx-local fork: when AWS_S3_ENDPOINT is set, route the legacy knox-s3 client
+// through the in-cluster s3-proxy (s3-reader/s3-writer chain) instead of vanilla
+// AWS S3, mirroring core/_services/storage/amazon.js. Bit-identical to upstream
+// when AWS_S3_ENDPOINT is unset. AWS_S3_FORCE_PATH_STYLE=true selects path-style
+// addressing (required by the proxy, which routes by /<bucket>/<key>).
+function parseEndpointOptions () {
+  const raw = process.env.AWS_S3_ENDPOINT
+  if (!raw) { return {} }
+  // knox wants a bare host (no scheme). https -> secure (default port), http -> port 80.
+  const secure = !/^http:\/\//i.test(raw)
+  const host = raw.replace(/^https?:\/\//i, '').replace(/\/+$/, '')
+  const opts = {
+    endpoint: host,
+    style: (process.env.AWS_S3_FORCE_PATH_STYLE === 'true') ? 'path' : 'virtualHosted'
+  }
+  // knox treats a defined `port` as non-secure (plain HTTP). Only set it for http endpoints.
+  if (!secure) { opts.port = 80 }
+  return opts
+}
+
 function findOrCreateS3Client (bucketName) {
   if (!s3Clients[bucketName]) {
     s3Clients[bucketName] = S3.createClient({
       key: process.env.AWS_ACCESS_KEY_ID,
       secret: process.env.AWS_SECRET_KEY,
       region: process.env.AWS_REGION_ID,
-      bucket: getBucket(bucketName)
+      bucket: getBucket(bucketName),
+      ...parseEndpointOptions()
     })
   }
   return s3Clients[bucketName]


### PR DESCRIPTION
## What

Make the legacy noncore audio-serving path honor `AWS_S3_ENDPOINT` (+ `AWS_S3_FORCE_PATH_STYLE`) so it can download source segments from a non-AWS, S3-compatible store (rfcx-local's in-cluster s3-proxy / MinIO).

## Why

`core/` was already adapted to the shared `@rfcx/s3-storage-client` (commit f592dfa), but the **legacy noncore audio path** was missed:

`/v1/assets/audio/<guid>.<ext>` → `audio-cache.cacheSourceAudio` → `noncore/_utils/external/aws.js` (`knox-s3`)

…ignored `AWS_S3_ENDPOINT` and went to vanilla AWS S3 with a key that only exists in MinIO → `InvalidAccessKeyId`. The error XML (344 bytes) got served as the "audio", and the mp3 transcode hung. On rfcx-local this broke **all** audio playback + transcode in the player app.

## How

`findOrCreateS3Client` now merges in `parseEndpointOptions()`:
- when `AWS_S3_ENDPOINT` is set → pass `endpoint` (scheme stripped) to knox, choose `style: 'path'` when `AWS_S3_FORCE_PATH_STYLE=true`, set `port: 80` for http endpoints (knox treats a defined port as non-secure).
- when `AWS_S3_ENDPOINT` is unset → **bit-identical to upstream** (no behavior change for AWS prod).

Note: the rfcx-local s3-proxy does not verify the inbound client signature (it re-signs per layer to the backing store), so knox's SigV2 is irrelevant here — verified an unsigned GET returns the object.

## Testing

On rfcx-local (image built from this branch, deployed to noncore-api):
- `/v1/assets/audio/<guid>.opus` → 200, real 60KB ogg/opus (was 344B error doc)
- `/v1/assets/audio/<guid>.mp3` → 200, real ID3 mp3, ffmpeg transcode (`transcoding opus audio to mp3` in logs; ffprobe confirms opus 48k mono → mp3 12k)
- `/v1/assets/audio/amplitude/<guid>.json` → 200
- Verified end-to-end in the Android player (Pixel 7): audio plays + waveform renders, zero AWS asset requests.

No change to AWS production behavior (endpoint var unset there).
