### PR TITLE
auth: attribute identity-less tokens by sub/client + rate-limit segment-file downloads

### DIFF
--- a/common/crypto/random.js
+++ b/common/crypto/random.js
@@ -1,4 +1,5 @@
 const csprng = require('csprng')
+const crypto = require('crypto')
 /**
    * A CSPRNG random string
    *
@@ -30,4 +31,24 @@ function randomGuid () {
         s4() + '-' + s4() + s4() + s4()
 }
 
-module.exports = { randomString, randomId, randomGuid }
+/**
+   * A DETERMINISTIC, UUID-v5-shaped guid derived from an input string, so the
+   * same input (e.g. an auth0 `sub` or a machine client id) always maps to the
+   * same users.guid. Used to give identity-less-but-signed tokens a stable
+   * principal instead of collapsing them onto the shared `userless` account.
+   *
+   * @param {string} input
+   * @return {string} deterministic 36-char UUID-shaped identifier
+   */
+function stableGuidFromString (input) {
+  const h = crypto.createHash('sha1').update(String(input)).digest('hex')
+  return [
+    h.slice(0, 8),
+    h.slice(8, 12),
+    '5' + h.slice(13, 16), // version nibble -> 5 (name-based)
+    ((parseInt(h.slice(16, 17), 16) & 0x3 | 0x8).toString(16)) + h.slice(17, 20), // variant
+    h.slice(20, 32)
+  ].join('-')
+}
+
+module.exports = { randomString, randomId, randomGuid, stableGuidFromString }

--- a/common/middleware/passport-jwt/index.js
+++ b/common/middleware/passport-jwt/index.js
@@ -2,7 +2,7 @@ const JwtStrategy = require('passport-jwt').Strategy
 const ExtractJwt = require('passport-jwt').ExtractJwt
 const jwksRsa = require('jwks-rsa-passport-edition')
 const userService = require('../../users')
-const { randomGuid } = require('../../../common/crypto/random')
+const { randomGuid, stableGuidFromString } = require('../../../common/crypto/random')
 const { getUserRolesFromToken } = require('../../auth0')
 
 const jwtExtractor = ExtractJwt.fromAuthHeaderAsBearerToken()
@@ -40,13 +40,50 @@ function combineUserData (jwtPayload, user) {
 function checkDBUser (req, jwtPayload, done) {
   const rfcxAppMetaUrl = 'https://rfcx.org/app_metadata'
   const tokenUserGuid = jwtPayload.guid || (jwtPayload[rfcxAppMetaUrl] ? jwtPayload[rfcxAppMetaUrl].guid : undefined)
-  // if request was sent from userless account (like GAIA), then use static user
+  // Identity-less token handling.
+  //
+  // Historically ANY token without an `email` claim AND without an
+  // app_metadata.guid was collapsed onto the shared static user
+  // `userless@rfcx.org`. That is too aggressive: it also swallows
+  //   (a) real human accounts whose access token simply lacks the custom
+  //       `https://rfcx.org/...` claims (e.g. minimally-scoped SDK tokens), and
+  //   (b) machine-to-machine client-credentials tokens,
+  // making them indistinguishable from a truly anonymous caller in logs and in
+  // `created_by` attribution. We now derive a stable principal from the token
+  // `sub`/`azp` first, and only fall back to `userless` when there is genuinely
+  // no identifying claim at all. This is attribution-only: authorization (roles
+  // + DB membership) is unchanged, so it cannot grant or remove access.
   if (!jwtPayload.email && !tokenUserGuid) {
-    jwtPayload.isStaticUser = true
-    jwtPayload.email = 'userless@rfcx.org'
-    jwtPayload.given_name = 'userless'
-    jwtPayload.family_name = 'rfcx'
-    jwtPayload.guid = randomGuid()
+    const sub = typeof jwtPayload.sub === 'string' ? jwtPayload.sub : ''
+    const isClientCredentials = jwtPayload.gty === 'client-credentials' || /@clients$/.test(sub)
+    if (isClientCredentials) {
+      // Machine client. Stable per-client identity so M2M traffic is
+      // attributable per application instead of pooling into `userless`.
+      const clientId = sub.replace(/@clients$/, '') || jwtPayload.azp || 'unknown'
+      jwtPayload.isStaticUser = true
+      jwtPayload.isMachineClient = true
+      jwtPayload.email = `${clientId}@clients.rfcx.org`
+      jwtPayload.given_name = 'client'
+      jwtPayload.family_name = clientId
+      jwtPayload.guid = stableGuidFromString(`client:${clientId}`)
+    } else if (sub) {
+      // Real (human) account whose token omitted the custom email/guid claims.
+      // Attribute to the auth0 subject (stable guid from `sub`). We do not invent
+      // a trustworthy email; findOrCreateUser matches on guid. An out-of-band
+      // Auth0 Management backfill can enrich email+name later.
+      jwtPayload.isStaticUser = false
+      jwtPayload.guid = stableGuidFromString(`sub:${sub}`)
+      jwtPayload.email = jwtPayload.email || `${sub.replace(/[^a-zA-Z0-9]/g, '_')}@subject.rfcx.org`
+      jwtPayload.given_name = jwtPayload.given_name || 'auth0'
+      jwtPayload.family_name = jwtPayload.family_name || sub
+    } else {
+      // Genuinely no identity (legacy GAIA-style). Preserve original behaviour.
+      jwtPayload.isStaticUser = true
+      jwtPayload.email = 'userless@rfcx.org'
+      jwtPayload.given_name = 'userless'
+      jwtPayload.family_name = 'rfcx'
+      jwtPayload.guid = randomGuid()
+    }
   }
 
   if (jwtPayload.email === 'anonymous-assistant@rfcx.org') {

--- a/common/middleware/rate-limit/per-principal.js
+++ b/common/middleware/rate-limit/per-principal.js
@@ -1,0 +1,63 @@
+/**
+ * per-principal.js — tiny, dependency-free, in-memory sliding-window rate
+ * limiter keyed on the authenticated principal (user id / guid).
+ *
+ * Motivation: a single authenticated principal (an SDK/M2M client) was able to
+ * pull whole public-stream audio archives via the segment-file endpoint at
+ * several requests/second with no server-side ceiling. This applies a fair,
+ * per-principal cap so any one caller cannot monopolise the endpoint, without
+ * allow/deny lists and without affecting other users.
+ *
+ * Notes / limitations:
+ *  - In-memory and per-process. rfcx-api runs multiple replicas, so the
+ *    effective fleet ceiling is `max` * replicaCount. That is acceptable here
+ *    (the goal is to stop runaway single-client bulk pulls, not to enforce an
+ *    exact global quota). For a strict global limit, back this with Redis.
+ *  - Window state is pruned lazily; memory stays bounded by active principals.
+ */
+
+function createPerPrincipalRateLimit ({ windowMs = 60000, max = 60, message } = {}) {
+  const hits = new Map() // key -> array of request timestamps (ms)
+
+  return function perPrincipalRateLimit (req, res, next) {
+    const info = (req.rfcx && req.rfcx.auth_token_info) || {}
+    // Super users and internal system-role callers bypass the limit.
+    if (info.is_super || info.has_system_role) {
+      return next()
+    }
+    const key = String(info.id || info.guid || req.headers['cf-connecting-ip'] || req.ip || 'anonymous')
+
+    const now = Date.now()
+    const windowStart = now - windowMs
+    const arr = (hits.get(key) || []).filter(ts => ts > windowStart)
+
+    if (arr.length >= max) {
+      const retryAfterSec = Math.max(1, Math.ceil((arr[0] + windowMs - now) / 1000))
+      res.set('Retry-After', String(retryAfterSec))
+      hits.set(key, arr) // keep pruned window
+      return res.status(429).json({
+        message: message || 'Too many requests for this resource. Please slow down.',
+        error: { status: 429 }
+      })
+    }
+
+    arr.push(now)
+    hits.set(key, arr)
+
+    // Opportunistic global prune so the Map doesn't grow unbounded.
+    if (hits.size > 5000) {
+      for (const [k, v] of hits) {
+        const pruned = v.filter(ts => ts > windowStart)
+        if (pruned.length === 0) {
+          hits.delete(k)
+        } else {
+          hits.set(k, pruned)
+        }
+      }
+    }
+
+    return next()
+  }
+}
+
+module.exports = { createPerPrincipalRateLimit }

--- a/core/stream-segments/index.js
+++ b/core/stream-segments/index.js
@@ -1,7 +1,19 @@
 const router = require('express').Router()
+const { createPerPrincipalRateLimit } = require('../../common/middleware/rate-limit/per-principal')
+
+// Per-principal cap on full-segment-FILE downloads. This endpoint 302-redirects
+// to a signed object URL for the whole audio segment; a single caller pulling
+// these in a tight loop can bulk-export an entire (public) stream archive and
+// hammer storage. Cap per authenticated principal; super/system callers bypass.
+// In-memory + per-replica (see middleware notes); env-tunable.
+const segmentFileRateLimit = createPerPrincipalRateLimit({
+  windowMs: parseInt(process.env.SEGMENT_FILE_RATE_WINDOW_MS || '60000', 10),
+  max: parseInt(process.env.SEGMENT_FILE_RATE_MAX || '120', 10),
+  message: 'Too many segment file downloads. Please slow down or contact the Arbimon team to arrange a bulk export.'
+})
 
 router.get('/:id/segments', require('./list'))
 router.get('/:id/segments/:start', require('./get'))
-router.get('/:id/segments/:start/file', require('./file'))
+router.get('/:id/segments/:start/file', segmentFileRateLimit, require('./file'))
 
 module.exports = router


### PR DESCRIPTION
## Summary
Fixes two related issues uncovered while investigating a bulk audio-scrape incident (2026-06-24): identity-less tokens being mis-attributed to a shared anonymous user, and the segment-file download endpoint having no per-caller ceiling.

### 1. Attribute identity-less-but-signed tokens (passport-jwt)
`common/middleware/passport-jwt/index.js` collapsed **any** token without an `email` claim AND without an `app_metadata.guid` onto the shared static user `userless@rfcx.org`. That swallowed:
- real **human** accounts whose access token simply omits the custom `https://rfcx.org/...` claims (e.g. minimally-scoped SDK / `python-httpx` tokens), and
- **machine-to-machine** client-credentials tokens.

…making them indistinguishable from a truly anonymous caller in logs and in `created_by` attribution. (In the incident, a real user’s SDK traffic showed up only as `userless@rfcx.org`.)

Now we derive a **stable principal**:
| token shape | principal |
|---|---|
| `gty=client-credentials` / `sub` ends `@clients` | `<client_id>@clients.rfcx.org` (stable guid) |
| any other token with a `sub` | stable guid derived from the auth0 `sub` |
| genuinely no `sub`/email/guid (legacy “GAIA”) | **unchanged** → `userless` fallback |

Stable guids come from a new `stableGuidFromString()` (UUID-v5-shaped sha1) in `common/crypto/random.js`, so the same `sub`/client maps to one `users` row.

**Attribution-only** — authorization (roles + DB membership) is untouched, so this cannot grant or remove access. It only makes the principal correct in logs and `created_by`.

### 2. Per-principal rate limit on segment-file downloads
`GET /streams/:id/segments/:start/file` 302-redirects to a signed URL for a whole audio segment. A single principal pulling these in a loop can bulk-export an entire (public) stream archive and hammer storage. Adds a small, **dependency-free** in-memory sliding-window limiter keyed on the authenticated principal:
- super / system-role callers bypass,
- tunable via `SEGMENT_FILE_RATE_MAX` (default 120) and `SEGMENT_FILE_RATE_WINDOW_MS` (default 60000),
- in-memory + per-replica (documented); back with Redis later if a strict global quota is needed.

## Test plan
- `node --check` + eslint (standard) clean on all changed files.
- Identity-less human token → resolves to a stable per-`sub` user instead of `userless`.
- client-credentials token → resolves to `<client_id>@clients.rfcx.org`.
- Token with no sub/email/guid → still `userless` (no behaviour change).
- >120 segment-file GETs/min from one principal → 429 + `Retry-After`; other users unaffected; super/system bypass.

## Context
Base = `master` (production line). Incident write-up + the live edge mitigation live in the private `evity-squibbon/rfcx-local` infra repo (`runbooks/INCIDENT-esp-segment-scrape-2026-06-24.md`). An edge 429 (public-router) is already deployed as the immediate stop; this PR is the durable, fair, correctly-attributed fix.
