### PR TITLE
db: remove app-level Sequelize PG read-split (defer to proxy)

### DIFF
--- a/common/db.js
+++ b/common/db.js
@@ -2,60 +2,14 @@ const Sequelize = require('sequelize')
 
 function getOptions (type) {
   const t = process.env.NODE_ENV === 'test'
-  // Optional read-replica routing.
+  // Read/write routing is handled by the infrastructure proxy layer
+  // (rfcx-local PostgreSQL HA), NOT by Sequelize. The app connects to a
+  // single endpoint (POSTGRES_HOSTNAME) and the proxy is responsible for
+  // directing writes to the primary and (optionally) reads to a replica.
   //
-  // When POSTGRES_REPLICA_HOSTNAME is set, Sequelize is configured
-  // with a `replication` block: SELECTs are auto-routed to the read
-  // pool, everything else (writes, transactions) goes to the write
-  // pool. When the env var is unset, behaviour is identical to the
-  // previous single-host configuration.
-  //
-  // Other replica connection params default to the primary's:
-  //   POSTGRES_REPLICA_PORT     -> POSTGRES_PORT
-  //   POSTGRES_REPLICA_USER     -> POSTGRES_USER
-  //   POSTGRES_REPLICA_PASSWORD -> POSTGRES_PASSWORD
-  // This matches the rfcx-local replica tier, where the replica
-  // exposes the same credentials as the primary (it's a physical/
-  // logical streaming replica, not a separate user surface).
-  //
-  // The read pool is weighted: the primary is listed
-  // POSTGRES_READ_PRIMARY_WEIGHT times alongside one replica entry.
-  // Sequelize round-robins across that pool, so weight=N gives an
-  // N:1 primary:replica read split. Default is 3 (75% primary,
-  // 25% replica), reflecting that the rfcx-local ms4 replica has
-  // roughly half the RAM of the ms5 primary (24 GiB vs 48 GiB) and
-  // a colder buffer pool; the primary's larger warm cache should
-  // continue serving most reads, with the replica acting as a
-  // release valve for extra capacity. Set the var to 0 to route
-  // all reads to the replica, or to a higher value to bias even
-  // further toward the primary.
-  const replicaHost = !t ? process.env.POSTGRES_REPLICA_HOSTNAME : null
-  const primaryReadWeight = replicaHost
-    ? Math.max(0, parseInt(process.env.POSTGRES_READ_PRIMARY_WEIGHT || '3', 10))
-    : 0
-  const primaryConn = {
-    host: process.env.POSTGRES_HOSTNAME,
-    port: process.env.POSTGRES_PORT,
-    username: process.env.POSTGRES_USER,
-    password: process.env.POSTGRES_PASSWORD
-  }
-  const replicaConn = replicaHost
-    ? {
-        host: replicaHost,
-        port: process.env.POSTGRES_REPLICA_PORT || process.env.POSTGRES_PORT,
-        username: process.env.POSTGRES_REPLICA_USER || process.env.POSTGRES_USER,
-        password: process.env.POSTGRES_REPLICA_PASSWORD || process.env.POSTGRES_PASSWORD
-      }
-    : null
-  const replicationConfig = replicaHost
-    ? {
-        write: { ...primaryConn },
-        read: [
-          ...Array(primaryReadWeight).fill(primaryConn),
-          replicaConn
-        ]
-      }
-    : null
+  // The previous app-level Sequelize `replication` block (added in
+  // rfcx/rfcx-api#654 "replica-routing") has been removed so it does not
+  // compete with the proxy's routing. See rfcx-local ADR-017 (Database HA).
   const options = {
     dialect: 'postgres',
     dialectOptions: {
@@ -68,7 +22,6 @@ function getOptions (type) {
     database: !t ? (type === 'core' ? process.env.CORE_DB_NAME : process.env.NONCORE_DB_NAME) : 'postgres',
     username: !t ? process.env.POSTGRES_USER : 'postgres',
     password: !t ? process.env.POSTGRES_PASSWORD : 'test',
-    ...(replicationConfig ? { replication: replicationConfig } : {}),
     migrationStorageTableName: 'migrations',
     migrationStorageTableSchema: 'sequelize',
     logging: false,


### PR DESCRIPTION
## What
Removes the Sequelize `replication` block from `common/db.js` (added in #654 replica-routing) that did app-level read/write splitting via `POSTGRES_REPLICA_HOSTNAME` + `POSTGRES_READ_PRIMARY_WEIGHT`.

## Why
rfcx-local is moving PostgreSQL routing to the infrastructure proxy layer (PostgreSQL HA — rfcx-local ADR-017), mirroring the MariaDB MaxScale model just deployed. The app now connects to a single `POSTGRES_HOSTNAME` endpoint and lets the proxy own write→primary / read→replica routing. Keeping app-level splitting would compete with the proxy.

## Safety
**No live behaviour change**: `POSTGRES_REPLICA_HOSTNAME` is unset in all prod apps today, so `replicationConfig` was already `null` (single-host). Diff is −54/+7, `node --check` + ESLint clean. Consumers (`core/_models/db.js`, `noncore/_models/db.js`) just pass through the export.