### PR TITLE
perf(streams-cache): cut latency on the spectrogram/segment serve path (develop sync of #662)

### DIFF
--- a/core/_services/storage/amazon.js
+++ b/core/_services/storage/amazon.js
@@ -1,13 +1,38 @@
 const fs = require('fs')
+const http = require('http')
+const https = require('https')
 const S3 = require('aws-sdk/clients/s3')
 
 // rfcx-local fork: support MinIO (or any S3-compatible endpoint) when
 // AWS_S3_ENDPOINT is set. Production with empty AWS_S3_ENDPOINT remains
 // bit-identical to upstream behavior.
+
+// ---------------------------------------------------------------------------
+// Connection reuse (rfcx-local, 2026-06-29). The AWS SDK v2 default HTTP agent
+// does NOT keep connections alive, so every headObject/getObject/putObject pays
+// a fresh TCP + TLS handshake. Against the in-cluster s3-proxy that handshake
+// measured 20-70ms of every call (TLS dominant) -- and the streams-cache hit
+// path issues a HEAD then a GET, so it paid it twice. A keep-alive agent
+// amortises the handshake across the pool, which is the single biggest latency
+// win on the UX-blocking spectrogram/segment serve path. maxSockets is bounded
+// so a burst of concurrent spectrogram requests can't exhaust ephemeral ports.
+// Tunable via S3_KEEPALIVE_MAX_SOCKETS (default 64).
+const S3_KEEPALIVE_MAX_SOCKETS = parseInt(process.env.S3_KEEPALIVE_MAX_SOCKETS || '64', 10)
+const keepAliveHttpAgent = new http.Agent({ keepAlive: true, maxSockets: S3_KEEPALIVE_MAX_SOCKETS })
+const keepAliveHttpsAgent = new https.Agent({ keepAlive: true, maxSockets: S3_KEEPALIVE_MAX_SOCKETS })
+
+// Pick the agent matching the configured endpoint scheme (https s3-proxy today;
+// http if a plain-HTTP internal endpoint is ever configured). Falls back to the
+// https agent for vanilla AWS (no custom endpoint).
+function agentForEndpoint (endpoint) {
+  return /^http:\/\//i.test(`${endpoint || ''}`) ? keepAliveHttpAgent : keepAliveHttpsAgent
+}
+
 const _s3Config = {
   accessKeyId: process.env.AWS_ACCESS_KEY_ID,
   secretAccessKey: process.env.AWS_SECRET_KEY,
-  region: process.env.AWS_REGION_ID
+  region: process.env.AWS_REGION_ID,
+  httpOptions: { agent: agentForEndpoint(process.env.AWS_S3_ENDPOINT) }
 }
 if (process.env.AWS_S3_ENDPOINT) {
   _s3Config.endpoint = process.env.AWS_S3_ENDPOINT
@@ -15,6 +40,44 @@ if (process.env.AWS_S3_ENDPOINT) {
   _s3Config.signatureVersion = 'v4'
 }
 const s3Client = new S3(_s3Config)
+
+// ---------------------------------------------------------------------------
+// Dedicated streams-cache client (rfcx-local, 2026-06-29). The streams-cache
+// bucket is an in-cluster-only result cache (regeneratable, no durable tier).
+// The default s3Client must keep using AWS_S3_ENDPOINT (= https://s3.arbimon.org)
+// because it ALSO mints public presigned browser URLs and serves the source
+// `streams` bucket -- so we must NOT flip its endpoint globally. Instead, when
+// STREAMS_CACHE_S3_ENDPOINT is set, cache-bucket reads/writes use a SEPARATE
+// client pointed at that internal endpoint (e.g. a plain-HTTP in-cluster route
+// to s3-reader/s3-writer), skipping the TLS hop entirely. Default-off: when the
+// env var is unset, cacheS3Client === s3Client, so behaviour is unchanged until
+// the internal route exists and the var is flipped.
+const STREAMS_CACHE_S3_ENDPOINT = process.env.STREAMS_CACHE_S3_ENDPOINT
+let cacheS3Client = s3Client
+if (STREAMS_CACHE_S3_ENDPOINT) {
+  cacheS3Client = new S3({
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_KEY,
+    region: process.env.AWS_REGION_ID,
+    endpoint: STREAMS_CACHE_S3_ENDPOINT,
+    s3ForcePathStyle: true,
+    signatureVersion: 'v4',
+    httpOptions: { agent: agentForEndpoint(STREAMS_CACHE_S3_ENDPOINT) }
+  })
+}
+
+// The streams-cache bucket name, so the read/write helpers can pick the right
+// client without every caller passing it. Mirrors core/_services/storage index.
+const STREAMS_CACHE_BUCKET = process.env.STREAMS_CACHE_BUCKET || 'rfcx-streams-cache-testing'
+
+// Route a given bucket's operations to the cache client when it is the
+// streams-cache bucket AND a dedicated cache endpoint is configured; otherwise
+// the default client. Bucket-scoped on purpose: `upload` is also used for other
+// buckets (e.g. classifier uploads), and download/deleteFiles target the source
+// `streams` bucket -- those must stay on the default client.
+function clientForBucket (Bucket) {
+  return Bucket === STREAMS_CACHE_BUCKET ? cacheS3Client : s3Client
+}
 
 function getSignedUrl (bucket, key, contentType, expires = 86400, write = false) {
   const params = {
@@ -36,15 +99,16 @@ function getSignedUrl (bucket, key, contentType, expires = 86400, write = false)
 }
 
 function exists (Bucket, Key) {
+  const client = clientForBucket(Bucket)
   return new Promise((resolve, reject) => {
-    s3Client.headObject({ Bucket, Key }, (headErr, data) => {
+    client.headObject({ Bucket, Key }, (headErr, data) => {
       return resolve(!headErr)
     })
   })
 }
 
 async function listFiles (Bucket, path) {
-  const files = await s3Client.listObjects({ Bucket, Prefix: path }).promise()
+  const files = await clientForBucket(Bucket).listObjects({ Bucket, Prefix: path }).promise()
   return files.Contents
 }
 
@@ -85,9 +149,39 @@ function download (Bucket, remotePath, localPath) {
 }
 
 function getReadStream (Bucket, Key) {
-  return s3Client
+  return clientForBucket(Bucket)
     .getObject({ Bucket, Key })
     .createReadStream()
+}
+
+// Single round-trip cache read (rfcx-local, 2026-06-29). Resolves with a
+// readable stream on a 2xx, or `null` when the object is absent (404/403) or
+// the backend is unreachable -- both treated as a cache MISS by callers. This
+// replaces the prior HEAD-then-GET pair on the hot serve path: one request
+// instead of two, halving the cache-hit round-trips on the UX-blocking
+// spectrogram/segment endpoint. We branch on the SDK v2 `httpHeaders` event so
+// we never start writing the client response until we know it is a hit.
+function getObjectStreamOrNull (Bucket, Key) {
+  return new Promise((resolve) => {
+    const req = clientForBucket(Bucket).getObject({ Bucket, Key })
+    let settled = false
+    const finish = (value) => { if (!settled) { settled = true; resolve(value) } }
+    const stream = req.createReadStream()
+    req.on('httpHeaders', (statusCode) => {
+      if (statusCode >= 200 && statusCode < 300) {
+        finish(stream)
+      } else {
+        // Miss (e.g. NoSuchKey -> 404). Discard the error body quietly so the
+        // socket can be reused by the keep-alive pool, then report a miss.
+        stream.on('error', () => {})
+        stream.resume()
+        finish(null)
+      }
+    })
+    // Network-level failure before any headers (ECONNREFUSED, TLS, timeout):
+    // fall back to regeneration rather than 500-ing the request.
+    stream.on('error', () => finish(null))
+  })
 }
 
 function upload (Bucket, Key, localPath) {
@@ -97,7 +191,7 @@ function upload (Bucket, Key, localPath) {
     Key,
     Body: fileStream
   }
-  return s3Client.putObject(opts).promise()
+  return clientForBucket(Bucket).putObject(opts).promise()
 }
 
 function uploadBuffer (Bucket, Key, buffer) {
@@ -106,12 +200,12 @@ function uploadBuffer (Bucket, Key, buffer) {
     Key,
     Body: buffer
   }
-  return s3Client.upload(opts).promise()
+  return clientForBucket(Bucket).upload(opts).promise()
 }
 
 function deleteFile (Bucket, Key) {
   const opts = { Bucket, Key }
-  return s3Client.deleteObject(opts).promise()
+  return clientForBucket(Bucket).deleteObject(opts).promise()
 }
 
 function deleteFiles (Bucket, Keys) {
@@ -139,6 +233,7 @@ module.exports = {
   getFilePath,
   download,
   getReadStream,
+  getObjectStreamOrNull,
   upload,
   uploadBuffer,
   deleteFile,

--- a/core/_services/storage/amazon.unit.test.js
+++ b/core/_services/storage/amazon.unit.test.js
@@ -1,0 +1,102 @@
+// Unit tests for the rfcx-local streams-cache latency changes (2026-06-29):
+// the single round-trip cache read `getObjectStreamOrNull`. We mock aws-sdk so
+// no network/credentials are needed. Behaviour contract:
+//   - 2xx  -> resolves the readable stream (cache HIT)
+//   - 4xx  -> resolves null (cache MISS), draining the error body
+//   - error before headers -> resolves null (treat unreachable as MISS)
+
+// The mock factory is hoisted by jest, so it must be fully self-contained and
+// may only reference globals. We stash the desired behaviour on globalThis and
+// build the fake S3 inside the factory.
+global.__s3Behaviour = { type: 'hit' }
+
+jest.mock('aws-sdk', () => {
+  const { PassThrough } = require('stream')
+  function makeFakeS3 () {
+    return {
+      getObject () {
+        const behaviour = global.__s3Behaviour
+        const stream = new PassThrough()
+        const handlers = {}
+        const req = {
+          on (event, cb) { handlers[event] = cb; return req },
+          createReadStream () { return stream }
+        }
+        process.nextTick(() => {
+          if (behaviour.type === 'hit') {
+            if (handlers.httpHeaders) { handlers.httpHeaders(200, {}) }
+            stream.end(Buffer.from('payload'))
+          } else if (behaviour.type === 'miss') {
+            if (handlers.httpHeaders) { handlers.httpHeaders(404, {}) }
+            stream.emit('error', Object.assign(new Error('NoSuchKey'), { statusCode: 404 }))
+          } else if (behaviour.type === 'neterror') {
+            stream.emit('error', new Error('ECONNREFUSED'))
+          }
+        })
+        return req
+      },
+      headObject (params, cb) { cb(null, {}) },
+      putObject () { return { promise: () => Promise.resolve({}) } }
+    }
+  }
+  return { S3: function () { return makeFakeS3() } }
+})
+
+// develop's amazon.js imports the S3 constructor directly via
+// `require('aws-sdk/clients/s3')`, so mock that path too (returns the same fake
+// constructor). Mocking both paths keeps this test valid regardless of which
+// import style the storage module uses.
+jest.mock('aws-sdk/clients/s3', () => {
+  const { PassThrough } = require('stream')
+  function makeFakeS3 () {
+    return {
+      getObject () {
+        const behaviour = global.__s3Behaviour
+        const stream = new PassThrough()
+        const handlers = {}
+        const req = {
+          on (event, cb) { handlers[event] = cb; return req },
+          createReadStream () { return stream }
+        }
+        process.nextTick(() => {
+          if (behaviour.type === 'hit') {
+            if (handlers.httpHeaders) { handlers.httpHeaders(200, {}) }
+            stream.end(Buffer.from('payload'))
+          } else if (behaviour.type === 'miss') {
+            if (handlers.httpHeaders) { handlers.httpHeaders(404, {}) }
+            stream.emit('error', Object.assign(new Error('NoSuchKey'), { statusCode: 404 }))
+          } else if (behaviour.type === 'neterror') {
+            stream.emit('error', new Error('ECONNREFUSED'))
+          }
+        })
+        return req
+      },
+      headObject (params, cb) { cb(null, {}) },
+      putObject () { return { promise: () => Promise.resolve({}) } }
+    }
+  }
+  return function () { return makeFakeS3() }
+})
+
+const storage = require('./amazon')
+
+describe('getObjectStreamOrNull', () => {
+  test('resolves a readable stream on a 2xx (cache hit)', async () => {
+    global.__s3Behaviour = { type: 'hit' }
+    const result = await storage.getObjectStreamOrNull('rfcx-streams-cache-testing', 'k')
+    expect(result).not.toBeNull()
+    expect(typeof result.pipe).toBe('function')
+  })
+
+  test('resolves null on a 404 (cache miss)', async () => {
+    global.__s3Behaviour = { type: 'miss' }
+    const result = await storage.getObjectStreamOrNull('rfcx-streams-cache-testing', 'k')
+    expect(result).toBeNull()
+  })
+
+  test('resolves null on a network error before headers', async () => {
+    global.__s3Behaviour = { type: 'neterror' }
+    const result = await storage.getObjectStreamOrNull('rfcx-streams-cache-testing', 'k')
+    expect(result).toBeNull()
+  })
+})

--- a/core/_services/storage/google.js
+++ b/core/_services/storage/google.js
@@ -41,6 +41,27 @@ function getReadStream (bucket, key) {
   return storage.bucket(bucket).file(key).createReadStream()
 }
 
+// Single round-trip cache read parity with amazon.js (rfcx-local, 2026-06-29).
+// Resolves a readable stream on hit, or null on miss (404) / error, so callers
+// can avoid a separate exists() round-trip. GCS surfaces a missing object as a
+// stream 'error' with code 404.
+function getObjectStreamOrNull (bucket, key) {
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (value) => { if (!settled) { settled = true; resolve(value) } }
+    const stream = storage.bucket(bucket).file(key).createReadStream()
+    stream.once('error', () => finish(null))
+    stream.once('response', (resp) => {
+      if (resp && resp.statusCode >= 200 && resp.statusCode < 300) {
+        finish(stream)
+      } else {
+        stream.on('error', () => {})
+        finish(null)
+      }
+    })
+  })
+}
+
 function upload (bucket, key, localPath) {
   return storage.bucket(bucket).upload(localPath, { destination: key })
 }
@@ -67,6 +88,7 @@ module.exports = {
   getFilePath,
   download,
   getReadStream,
+  getObjectStreamOrNull,
   upload,
   uploadBuffer,
   deleteFile,

--- a/core/stream-segments/bl/segment-file-utils.js
+++ b/core/stream-segments/bl/segment-file-utils.js
@@ -34,13 +34,23 @@ async function getFile (req, res, attrs, fileExtension, segments, nextTimestamp)
     additionalHeaders['RFCx-Stream-Next-Timestamp'] = nextTimestamp
   }
 
-  const getFromCache = MEDIA_CACHE_ENABLED ? await storageService.exists(storageService.buckets.streamsCache, storageFilePath) : false
-  if (getFromCache) {
+  // Single round-trip cache hit (rfcx-local, 2026-06-29): one GET that returns a
+  // stream on hit or null on miss, instead of a HEAD (exists) followed by a
+  // separate GET. Halves the round-trips on the UX-blocking spectrogram/segment
+  // serve path. On a miss (or any cache-backend error) we fall through to
+  // regeneration exactly as before.
+  const cacheStream = MEDIA_CACHE_ENABLED
+    ? await storageService.getObjectStreamOrNull(storageService.buckets.streamsCache, storageFilePath)
+    : null
+  if (cacheStream) {
     res.attachment(attrs.fileType === 'spec' ? spectrogramFilename : audioFilename)
     for (const key in additionalHeaders) {
       res.setHeader(key, additionalHeaders[key])
     }
-    return storageService.getReadStream(storageService.buckets.streamsCache, storageFilePath).pipe(res)
+    // If the cache read errors mid-stream after headers are sent we can't
+    // recover the response; log and let the socket close.
+    cacheStream.on('error', (err) => { console.error('streams-cache read error', err && err.message) })
+    return cacheStream.pipe(res)
   } else {
     return generateFile(req, res, attrs, fileExtension, segments, additionalHeaders)
   }
@@ -342,20 +352,14 @@ async function generateFile (req, res, attrs, fileExtension, segments, additiona
     spectrogramFilename = await makeSpectrogram(audioFilePath, spectrogramFilePath, spectrogramFilename, fileExtension, attrs)
     spectrogramFilePath = `${tmpDir}${spectrogramFilename}`
   }
+  // Clone the freshly generated files BEFORE serving: serveAudioFromFile()
+  // unlinks the file it streams on completion, so the cache writeback needs a
+  // stable copy that outlives the response.
   const { audioFilePathCached, spectrogramFilePathCached } = MEDIA_CACHE_ENABLED ? await cloneFiles(audioFilePath, attrs.fileType === 'spec' ? spectrogramFilePath : null) : {}
   if (attrs.fileType === 'spec') {
     await audioUtils.serveAudioFromFile(res, spectrogramFilePath, spectrogramFilename, `image/${fileExtension}`, !!req.query.inline, additionalHeaders)
   } else {
     await audioUtils.serveAudioFromFile(res, audioFilePath, audioFilename, assetUtils.mimeTypeFromAudioCodec(attrs.fileType), !!req.query.inline, additionalHeaders)
-  }
-  if (MEDIA_CACHE_ENABLED) {
-    const args = [
-      attrs.streamId,
-      audioFilename,
-      audioFilePathCached,
-      ...attrs.fileType === 'spec' ? [spectrogramFilename, spectrogramFilePathCached] : []
-    ]
-    await uploadCachedFiles(...args)
   }
   const clearArgs = [
     segments,
@@ -363,7 +367,26 @@ async function generateFile (req, res, attrs, fileExtension, segments, additiona
     ...attrs.fileType === 'spec' ? [audioFilePath] : [null],
     ...(attrs.fileType === 'spec' && MEDIA_CACHE_ENABLED) ? [spectrogramFilePathCached] : [null]
   ]
-  deleteLocalFiles(...clearArgs)
+  // Fire-and-forget the cache writeback (rfcx-local, 2026-06-29). The user's
+  // response is already fully streamed at this point, so blocking the handler
+  // on the cache PUT only adds latency + holds the request open under the
+  // concurrent, UX-blocking spectrogram load. Run the PUT in the background and
+  // only then delete the local temp files (the cache PUT reads the cloned
+  // copies). On a non-cache request, clean up immediately. Mirrors the
+  // already-async writeback in core/internal/explorer/indices-heatmap.js.
+  if (MEDIA_CACHE_ENABLED) {
+    const args = [
+      attrs.streamId,
+      audioFilename,
+      audioFilePathCached,
+      ...attrs.fileType === 'spec' ? [spectrogramFilename, spectrogramFilePathCached] : []
+    ]
+    uploadCachedFiles(...args)
+      .catch((err) => { console.error('streams-cache writeback failed', err && err.message) })
+      .finally(() => { deleteLocalFiles(...clearArgs) })
+  } else {
+    deleteLocalFiles(...clearArgs)
+  }
   segments = null
   attrs = null
 }


### PR DESCRIPTION
Develop-branch sync of **#662** (merged to `master` as `a74827f8c`), so the default branch doesn't drift from prod.

Adapted to develop's inline `new S3(_s3Config)` storage client — master had already migrated to the `@rfcx/s3-storage-client` factory, which develop does not carry yet, so a raw cherry-pick conflicted. Same env-var contract + behaviour; `google.js`, `segment-file-utils.js`, and the unit test are identical to #662 (the test additionally mocks `aws-sdk/clients/s3` to match develop's import style).

## The 4 changes (storage service + segment serve path; no infra/manifest changes)
1. **Keep-alive HTTP(S) agent** on the S3 client(s) — eliminates the per-call TCP+TLS handshake (TLS measured 20–70ms of every in-cluster call). Bounded `maxSockets` (`S3_KEEPALIVE_MAX_SOCKETS`, default 64).
2. **Optional dedicated streams-cache client** (`STREAMS_CACHE_S3_ENDPOINT`, **default-off**) — routes cache reads/writes to a plain-HTTP in-cluster endpoint (skip TLS) without touching the default client, which must keep `AWS_S3_ENDPOINT` (it mints public presigned browser URLs + serves the source `streams` bucket). Bucket-scoped via `clientForBucket()`. No-op until set.
3. **Single round-trip cache hit** — `getObjectStreamOrNull()` (GET; 404/err ⇒ miss) replaces HEAD-then-GET in `getFile()`. Parity impl in the google backend.
4. **Fire-and-forget cache writeback** — no longer blocks the handler; temp cleanup deferred to the PUT's `.finally`. Mirrors `core/internal/explorer/indices-heatmap.js`.

## Safety
- Unchanged when `MEDIA_CACHE_ENABLED=false` and when `STREAMS_CACHE_S3_ENDPOINT` unset.
- Cache-backend errors fall through to regeneration (no new 500s); presigned-URL generation untouched.

## Tests
- `core/_services/storage/amazon.unit.test.js` covers hit / miss(404) / network-error; `eslint` clean; `jest` green (39 tests).

🤖 rfcx-local agent session (ms4, 2026-06-29)