### PR TITLE
fix(core): require Arbimon project id on project create

### DIFF
--- a/core/projects/bl/index.js
+++ b/core/projects/bl/index.js
@@ -5,6 +5,15 @@ const { ForbiddenError } = require('../../../common/error-handling/errors')
 const arbimonService = require('../../_services/arbimon')
 const { randomId } = require('../../../common/crypto/random')
 
+function getArbimonProjectId (arbimonProject) {
+  const id = arbimonProject && (arbimonProject.project_id || arbimonProject.id)
+  if (id === undefined || id === null || id === '') {
+    return undefined
+  }
+  const numericId = Number(id)
+  return Number.isNaN(numericId) ? undefined : numericId
+}
+
 /**
  * Update project
  * @param {string} id
@@ -70,9 +79,14 @@ async function create (params, options = {}) {
     if (arbimonService.isEnabled && options.requestSource !== 'arbimon') {
       try {
         const arbimonProject = await arbimonService.createProject(project, options.idToken)
-        project.externalId = arbimonProject.project_id
+        const arbimonProjectId = getArbimonProjectId(arbimonProject)
+        if (arbimonProjectId === undefined) {
+          throw new Error(`Arbimon project create returned no project_id/id: ${JSON.stringify(arbimonProject)}`)
+        }
+        project.externalId = arbimonProjectId
       } catch (error) {
-        console.error(`Error creating project in Arbimon (project: ${project.id})`)
+        console.error(`Error creating project in Arbimon (project: ${project.id})`, error)
+        throw error
       }
     }
 

--- a/core/projects/create.int.test.js
+++ b/core/projects/create.int.test.js
@@ -1,6 +1,7 @@
 const request = require('supertest')
 const routes = require('.')
 const models = require('../_models')
+const arbimonService = require('../_services/arbimon')
 const { expressApp, truncateNonBase, seedValues } = require('../../common/testing/sequelize')
 
 const app = expressApp()
@@ -8,6 +9,8 @@ const app = expressApp()
 app.use('/', routes)
 
 afterEach(async () => {
+  arbimonService.isEnabled = false
+  jest.restoreAllMocks()
   await truncateNonBase(models)
 })
 
@@ -51,5 +54,18 @@ describe('POST /projects', () => {
 
     expect(response.statusCode).toBe(201)
     expect(userProjectRole.role_id).toBe(4)
+  })
+
+  test('stores Arbimon project id as external_id when Arbimon integration is enabled', async () => {
+    const arbimonProjectId = 9839
+    arbimonService.isEnabled = true
+    jest.spyOn(arbimonService, 'createProject').mockResolvedValue({ project_id: arbimonProjectId })
+
+    const response = await request(app).post('/').send({ name: 'Core with Arbimon project' })
+    const id = response.header.location.replace('/projects/', '')
+    const project = await models.Project.findByPk(id)
+
+    expect(response.statusCode).toBe(201)
+    expect(project.externalId).toBe(arbimonProjectId)
   })
 })


### PR DESCRIPTION
## Summary
- normalize Arbimon integration create responses that return either `project_id` or `id`
- rollback Core project creation instead of committing `external_id = NULL` when Arbimon does not return a usable legacy id
- add regression coverage for storing the returned Arbimon project id as Core `external_id`

## Live finding
Users creating Arbimon projects are hitting `notNull Violation: LocationProject.idArbimon cannot be null`. Live logs show Core successfully creating project rows, then Arbimon fetching `fields=external_id`; SELECT-only DB checks found 27 Core projects with `external_id IS NULL` in the last 24h. Legacy Arbimon rows do exist for the sampled Core IDs, so the failure is in the Core/Arbimon id handoff.

## Verification
- PASS: `./node_modules/.bin/eslint core/projects/bl/index.js core/projects/create.int.test.js`
- BLOCKED locally: `./node_modules/.bin/jest --runInBand --forceExit --config ./test/jest.int.config.js core/projects/create.int.test.js` because local test Postgres is not running (`SequelizeConnectionRefusedError` in `test/setup.js`). CI should run this with the test DB.
